### PR TITLE
feat: use Claude agent to generate branch names

### DIFF
--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -9,7 +9,7 @@ import { confirmPrompt, inputPrompt } from '../ui/prompts.js';
 import { isGitRepo, getRepoRoot, hasUncommittedChanges } from '../utils/git.js';
 import { readFileIfExists } from '../utils/fs.js';
 import { NotAGitRepoError, ClaudeNotFoundError } from '../utils/errors.js';
-import { slugifyTask, createWorktree } from '../core/worktree.js';
+import { generateBranchName, createWorktree } from '../core/worktree.js';
 import { openInNewTerminal } from '../core/terminal.js';
 import { buildAgentSystemPrompt } from '../prompts/agent-system.js';
 
@@ -86,8 +86,8 @@ export async function runCommand(options: RunOptions): Promise<void> {
     return;
   }
 
-  // ── Phase 3: Worktree Setup ─────────────────────────────────────────
-  const branchName = slugifyTask(task);
+  // ── Phase 3: Branch Name Generation ────────────────────────────────
+  const branchName = await withSpinner('Generating branch name...', () => generateBranchName(task));
   logger.info(`Branch: ${branchName}`);
 
   const proceed = await confirmPrompt('Create worktree and start Claude?', true);

--- a/tests/unit/worktree.test.ts
+++ b/tests/unit/worktree.test.ts
@@ -1,4 +1,34 @@
-import { slugifyTask } from '../../src/core/worktree.js';
+import { EventEmitter } from 'node:events';
+import { vi } from 'vitest';
+import { spawn } from 'node:child_process';
+import { slugifyTask, generateBranchName } from '../../src/core/worktree.js';
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    spawn: vi.fn(),
+  };
+});
+
+const spawnMock = vi.mocked(spawn);
+
+function createMockProcess(stdout: string, exitCode: number) {
+  const proc = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter;
+    kill: ReturnType<typeof vi.fn>;
+  };
+  proc.stdout = new EventEmitter();
+  proc.kill = vi.fn();
+
+  // Emit data and close on next tick
+  process.nextTick(() => {
+    proc.stdout.emit('data', Buffer.from(stdout));
+    proc.emit('close', exitCode);
+  });
+
+  return proc;
+}
 
 describe('slugifyTask', () => {
   it('should create a branch name with cf/ prefix', () => {
@@ -17,7 +47,8 @@ describe('slugifyTask', () => {
   });
 
   it('should truncate long descriptions to 50 chars before the hash', () => {
-    const longDesc = 'This is a very long task description that should be truncated to fifty characters';
+    const longDesc =
+      'This is a very long task description that should be truncated to fifty characters';
     const result = slugifyTask(longDesc);
     // cf/ prefix + slug (max 50) + - + 6-char hash
     const parts = result.split('-');
@@ -47,5 +78,97 @@ describe('slugifyTask', () => {
   it('should handle description with only special characters', () => {
     const result = slugifyTask('!@#$%^&*()');
     expect(result).toMatch(/^cf\/-[a-f0-9]{6}$/);
+  });
+});
+
+describe('generateBranchName', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should use Claude output when it returns a valid branch name', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    spawnMock.mockReturnValueOnce(createMockProcess('cf/feat/add-jwt-auth\n', 0) as any);
+
+    const result = await generateBranchName('Add JWT authentication');
+    expect(result).toMatch(/^cf\/feat\/add-jwt-auth-[a-f0-9]{6}$/);
+  });
+
+  it('should extract branch name from Claude output with extra text', async () => {
+    spawnMock.mockReturnValueOnce(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      createMockProcess('Here is the branch name: cf/fix/resolve-null-check\n', 0) as any,
+    );
+
+    const result = await generateBranchName('Fix null pointer error');
+    expect(result).toMatch(/^cf\/fix\/resolve-null-check-[a-f0-9]{6}$/);
+  });
+
+  it('should fall back to slugifyTask when Claude returns invalid output', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    spawnMock.mockReturnValueOnce(createMockProcess('invalid-branch-name\n', 0) as any);
+
+    const result = await generateBranchName('Add auth');
+    // Falls back to slugifyTask format: cf/<slug>-<hash>
+    expect(result).toMatch(/^cf\/add-auth-[a-f0-9]{6}$/);
+  });
+
+  it('should fall back to slugifyTask when Claude exits with error', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    spawnMock.mockReturnValueOnce(createMockProcess('', 1) as any);
+
+    const result = await generateBranchName('Add auth');
+    expect(result).toMatch(/^cf\/add-auth-[a-f0-9]{6}$/);
+  });
+
+  it('should fall back to slugifyTask when spawn fails', async () => {
+    const proc = new EventEmitter() as EventEmitter & {
+      stdout: EventEmitter;
+      kill: ReturnType<typeof vi.fn>;
+    };
+    proc.stdout = new EventEmitter();
+    proc.kill = vi.fn();
+    process.nextTick(() => {
+      proc.emit('error', new Error('spawn ENOENT'));
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    spawnMock.mockReturnValueOnce(proc as any);
+
+    const result = await generateBranchName('Add auth');
+    expect(result).toMatch(/^cf\/add-auth-[a-f0-9]{6}$/);
+  });
+
+  it('should accept all valid conventional commit types', async () => {
+    const types = ['feat', 'fix', 'refactor', 'chore', 'docs', 'test'];
+    for (const type of types) {
+      spawnMock.mockReturnValueOnce(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        createMockProcess(`cf/${type}/some-description\n`, 0) as any,
+      );
+      const result = await generateBranchName(`Some ${type} task`);
+      expect(result).toMatch(new RegExp(`^cf/${type}/some-description-[a-f0-9]{6}$`));
+    }
+  });
+
+  it('should append a 6-character hash suffix to Claude output', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    spawnMock.mockReturnValueOnce(createMockProcess('cf/feat/add-auth\n', 0) as any);
+
+    const result = await generateBranchName('Add authentication');
+    const hash = result.split('-').pop();
+    expect(hash).toMatch(/^[a-f0-9]{6}$/);
+  });
+
+  it('should pass the task description to Claude in the prompt', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    spawnMock.mockReturnValueOnce(createMockProcess('cf/feat/add-auth\n', 0) as any);
+
+    await generateBranchName('Add JWT authentication');
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      'claude',
+      ['--print', expect.stringContaining('Add JWT authentication')],
+      expect.any(Object),
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Added `generateBranchName()` in `src/core/worktree.ts` that calls `claude --print` to generate a meaningful branch name (e.g. `cf/feat/add-jwt-auth-a3f2c1`) from the task description
- Updated `src/commands/run.ts` to use `generateBranchName` instead of `slugifyTask`, with a spinner during generation
- Falls back to the original `slugifyTask` if Claude is unavailable, times out, or returns an invalid name
- Added 8 unit tests covering success, fallback, and edge cases

**Risk tier**: Tier 3 (modifies `src/commands/run.ts` and `src/core/worktree.ts` — critical paths)

## Files modified
- `src/core/worktree.ts` — new `generateBranchName` function using `spawn('claude', ['--print', ...])`
- `src/commands/run.ts` — replaced `slugifyTask` with `generateBranchName` + spinner
- `tests/unit/worktree.test.ts` — 8 new tests for `generateBranchName`

## Test plan
- [x] `npm run lint` — passes
- [x] `npm run typecheck` — passes
- [x] `npm test` — 88 tests pass (8 new)
- [x] `npm run build` — builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)