### PR TITLE
feat: encode autonomous loop and Chrome DevTools MCP into CI prompts

### DIFF
--- a/src/harnesses/claude-md.ts
+++ b/src/harnesses/claude-md.ts
@@ -23,6 +23,9 @@ export const claudeMdHarness: HarnessModule = {
         harnessName: 'claude-md',
         filesCreated: result.filesCreated,
         filesModified: result.filesModified,
+        metadata: {
+          targetFiles: ['CLAUDE.md', '.mcp.json'],
+        },
       };
 
       ctx.previousOutputs.set('claude-md', output);

--- a/src/prompts/claude-md.ts
+++ b/src/prompts/claude-md.ts
@@ -4,10 +4,7 @@ import type { DetectionResult, UserPreferences } from './types.js';
  * Prompt for generating the CLAUDE.md agent instructions file.
  */
 export function buildClaudeMdPrompt(detection: DetectionResult, prefs: UserPreferences): string {
-  const criticalPaths = [
-    ...detection.criticalPaths,
-    ...(prefs.customCriticalPaths ?? []),
-  ];
+  const criticalPaths = [...detection.criticalPaths, ...(prefs.customCriticalPaths ?? [])];
 
   return `Generate a \`CLAUDE.md\` file for this repository. CLAUDE.md is the primary instruction file that AI coding agents (Claude Code, Cursor, etc.) read before making changes. It must be concise (~100 lines), authoritative, and contain everything an agent needs to work safely in this codebase.
 
@@ -33,7 +30,7 @@ export function buildClaudeMdPrompt(detection: DetectionResult, prefs: UserPrefe
 
 ## Critical Paths
 
-${criticalPaths.map(p => `- \`${p}\``).join('\n') || '- none detected'}
+${criticalPaths.map((p) => `- \`${p}\``).join('\n') || '- none detected'}
 
 ## CLAUDE.md Structure Requirements
 
@@ -76,13 +73,13 @@ Concise bullet list covering:
 
 ### 4. Architecture Overview
 Brief description of the project's architectural layers:
-${detection.architecturalLayers.map(l => `- **${l}**: Brief description of this layer's responsibility`).join('\n') || '- Describe the observed directory structure and its purpose'}
+${detection.architecturalLayers.map((l) => `- **${l}**: Brief description of this layer's responsibility`).join('\n') || '- Describe the observed directory structure and its purpose'}
 
 Include a one-line dependency rule: which layers can import from which.
 
 ### 5. Critical Paths — Extra Care Required
 List the critical paths that require heightened attention:
-${criticalPaths.map(p => `- \`${p}\``).join('\n') || '- none identified'}
+${criticalPaths.map((p) => `- \`${p}\``).join('\n') || '- none identified'}
 
 State that changes to these paths:
 - Require additional test coverage
@@ -110,6 +107,7 @@ Brief note that this project uses harness engineering:
 - CI gates enforce risk-appropriate checks on every PR
 - A review agent will automatically review PRs
 - Pre-commit hooks enforce local quality checks
+- **Chrome DevTools MCP**: A \`.mcp.json\` file at the project root configures \`@modelcontextprotocol/server-puppeteer\` so agents can drive the browser directly — navigate flows, capture screenshots, inspect the DOM, and validate UI behavior
 - See \`docs/architecture.md\` and \`docs/conventions.md\` for detailed guidelines
 
 ### 9. PR Conventions
@@ -118,7 +116,28 @@ Brief note that this project uses harness engineering:
 - PRs must pass all CI checks before merge
 - Fill out the PR template completely, including risk tier classification
 
+## Additional Output Files
+
+### \`.mcp.json\`
+
+Also generate a \`.mcp.json\` file at the project root. This file configures the Chrome DevTools MCP server so all Claude agents working in this repository can drive the browser directly for validation tasks.
+
+The file must contain exactly:
+\`\`\`json
+{
+  "mcpServers": {
+    "puppeteer": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-puppeteer"],
+      "env": {}
+    }
+  }
+}
+\`\`\`
+
+With this in place, agents can use \`mcp__puppeteer__*\` tools to: navigate to pages, capture screenshots, click elements, read the DOM, observe console errors, and validate UI behavior — all without manual browser setup.
+
 ## Output Format
 
-Return ONLY the complete markdown content for CLAUDE.md. Target approximately 100 lines. Be concise — every line should provide actionable information to an AI agent. Do not include meta-commentary or explanations outside the file content.`;
+Return the complete markdown content for CLAUDE.md followed by the \`.mcp.json\` content. Separate the two files with a comment line indicating the target file path, e.g. \`# file: .mcp.json\`. Target approximately 100 lines for CLAUDE.md. Be concise — every line should provide actionable information to an AI agent. Do not include meta-commentary or explanations outside the file content.`;
 }


### PR DESCRIPTION
## Summary

Incorporates the **"Increasing levels of autonomy"** insight from OpenAI's harness engineering blog post into the prompts generated by the `init` command. The key idea: agents should drive tasks end-to-end — validate baseline, implement, validate fix, detect+remediate failures in a loop, and escalate **only** when human judgment is genuinely required.

Also adds Chrome DevTools MCP (via `@modelcontextprotocol/server-puppeteer`) as a default setup for all projects.

## Changes

- **`src/prompts/agent-system.ts`**: Added `## Autonomous Loop` section describing the full loop (baseline → implement → validate → detect+remediate → escalate only when judgment needed). Added `## Browser Validation` section for agents to use `mcp__puppeteer__*` tools when `.mcp.json` is present.

- **`src/prompts/issue-implementer.ts`**: Added Step 2 (baseline validation before branching), expanded Step 5 quality gates from a single retry to a detect→remediate→re-validate loop with per-strictness attempt limits, replaced generic "Failure handling" with precise escalation criteria (`agent:needs-judgment` only when judgment is actually required).

- **`src/prompts/remediation-loop.ts`**: Added baseline validation step before context gathering so agents can distinguish pre-existing failures from ones they introduced.

- **`src/prompts/claude-md.ts`**: Instructs the CLAUDE.md generation to also write `.mcp.json` with `@modelcontextprotocol/server-puppeteer` configured. Updated Harness System Reference section to mention Chrome DevTools MCP.

- **`src/harnesses/claude-md.ts`**: Added `.mcp.json` to `targetFiles` metadata.

- **`src/prompts/browser-evidence.ts`**: Updated capture script spec to use MCP tools (`mcp__puppeteer__navigate`, `mcp__puppeteer__screenshot`, etc.) when running in agent context, falling back to Puppeteer Node API in standalone CI runs.

## Test Results

All 109 tests pass. Lint, typecheck, and build clean.

## Risk Tier

**Tier 2** — modifies prompt templates that drive code generation. No changes to core engine, CLI entry points, or build infrastructure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)