### PR TITLE
fix: correct CF logo display — F was rendering as P

### DIFF
--- a/src/ui/banner.ts
+++ b/src/ui/banner.ts
@@ -5,7 +5,7 @@ import { getPackageInfo } from '../utils/package-info.js';
 const pkg = getPackageInfo();
 
 // "CF" monogram using box-drawing characters (single-width, renders correctly in all terminals)
-const CF_LOGO_LINES = ['╔══╗ ╔═══', '║    ╠══╝', '║    ║   ', '╚══╝ ╚   '];
+const CF_LOGO_LINES = ['╔══╗ ╔═══', '║    ╠═══', '║    ║   ', '╚══╝ ╚   '];
 
 const ACCENT = '#FF8C00'; // Orange, same aesthetic as Claude Code
 


### PR DESCRIPTION
## Summary
- Fixed the CLI banner logo where the "F" in "CF" was rendering as "P"
- The box-drawing character `╠══╝` closed the middle bar upward, creating an enclosed bump that resembled the letter P
- Changed to `╠═══` so the middle bar extends freely to the right, correctly displaying an F

## Files modified
- `src/ui/banner.ts` — single character change in the `CF_LOGO_LINES` constant

## Risk tier
Tier 1 — cosmetic UI change, no logic affected

## Test results
- Lint: pass
- Typecheck: pass
- Tests: 137/137 pass
- Build: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)