### PR TITLE
feat: add agent-pr label to agent system prompt

### DIFF
--- a/src/prompts/agent-system.ts
+++ b/src/prompts/agent-system.ts
@@ -76,7 +76,7 @@ You are on branch \`{{branchName}}\`. All commits go here.
 
 After all quality gates pass:
 1. Push the branch: \`git push -u origin {{branchName}}\`
-2. Create a PR: \`gh pr create --title "<short task summary>" --body "<summary of changes, files modified, test results>"\`
+2. Create a PR: \`gh pr create --label "agent-pr" --title "<short task summary>" --body "<summary of changes, files modified, test results>"\`
 3. Print the PR URL so the user can see it.`;
 
 function buildQualityGates(commands: AgentSystemPromptOptions['harnessCommands']): string {

--- a/tests/unit/agent-system.test.ts
+++ b/tests/unit/agent-system.test.ts
@@ -88,6 +88,16 @@ describe('buildAgentSystemPrompt', () => {
     expect(result).toContain('Execution Strategy');
   });
 
+  it('should include agent-pr label in gh pr create command', async () => {
+    const result = await buildAgentSystemPrompt({
+      branchName: 'cf/test',
+      repoRoot: tempDir,
+      harnessCommands: null,
+    });
+
+    expect(result).toContain('--label "agent-pr"');
+  });
+
   it('should replace all occurrences of branchName', async () => {
     const result = await buildAgentSystemPrompt({
       branchName: 'cf/multi-replace',


### PR DESCRIPTION
## Summary
- Added `--label "agent-pr"` to the `gh pr create` command in the agent system prompt template (`src/prompts/agent-system.ts`)
- This ensures PRs created by spawned Claude Code agents are labeled `agent-pr`, triggering the review process and post-PR hooks specific to agent PRs
- Added test coverage verifying the label is present in the generated prompt

## Files Modified
- `src/prompts/agent-system.ts` — added `--label "agent-pr"` to the `gh pr create` command in `DEFAULT_TEMPLATE`
- `tests/unit/agent-system.test.ts` — added test asserting the `agent-pr` label is included

## Test Results
- All 138 tests passing (17 test files)
- Lint, typecheck, and build all pass

## Risk Tier
Tier 2 — prompt template change with test coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)