### PR TITLE
fix: wrap overflowing text in CLI bordered input

### DIFF
--- a/src/ui/bordered-input.ts
+++ b/src/ui/bordered-input.ts
@@ -96,10 +96,24 @@ const _borderedInput = createPrompt<string, BorderedInputConfig>((config, done) 
     suggestionContent = '\n' + lines.join('\n');
   }
 
-  return [
-    top + '\n' + b('\u2502 ') + value,
-    bottom + (hint ? '\n' + hint : '') + suggestionContent,
-  ];
+  // Wrap value text so it stays inside the bordered box
+  const wrapWidth = cols;
+  const wrappedLines: string[] = [];
+  if (value.length === 0) {
+    wrappedLines.push('');
+  } else {
+    for (let i = 0; i < value.length; i += wrapWidth) {
+      wrappedLines.push(value.slice(i, i + wrapWidth));
+    }
+  }
+
+  const allButLast = wrappedLines.slice(0, -1);
+  const lastLine = wrappedLines[wrappedLines.length - 1] ?? '';
+  const prefixContent = allButLast.map((line) => b('\u2502 ') + line).join('\n');
+  const lastLineContent = b('\u2502 ') + lastLine;
+  const content = prefixContent ? prefixContent + '\n' + lastLineContent : lastLineContent;
+
+  return [top + '\n' + content, bottom + (hint ? '\n' + hint : '') + suggestionContent];
 });
 
 export function borderedInput(config: BorderedInputConfig): Promise<string> {


### PR DESCRIPTION
## Summary
- Text in the bordered input component (`src/ui/bordered-input.ts`) was overflowing past the box border when the input exceeded the available width
- Added character-based text wrapping that splits long input into multiple lines, each prefixed with the box border character `│`
- The wrap width matches the box inner width (`cols`), keeping text visually contained within the top/bottom borders

## Risk Tier
Tier 2 — UI-only change, no core logic affected

## Test plan
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` — 137 tests pass
- [x] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)