### PR TITLE
fix: correct cursor offset when text wraps in bordered input

### DIFF
--- a/src/ui/bordered-input.ts
+++ b/src/ui/bordered-input.ts
@@ -96,22 +96,12 @@ const _borderedInput = createPrompt<string, BorderedInputConfig>((config, done) 
     suggestionContent = '\n' + lines.join('\n');
   }
 
-  // Wrap value text so it stays inside the bordered box
-  const wrapWidth = cols;
-  const wrappedLines: string[] = [];
-  if (value.length === 0) {
-    wrappedLines.push('');
-  } else {
-    for (let i = 0; i < value.length; i += wrapWidth) {
-      wrappedLines.push(value.slice(i, i + wrapWidth));
-    }
-  }
-
-  const allButLast = wrappedLines.slice(0, -1);
-  const lastLine = wrappedLines[wrappedLines.length - 1] ?? '';
-  const prefixContent = allButLast.map((line) => b('\u2502 ') + line).join('\n');
-  const lastLineContent = b('\u2502 ') + lastLine;
-  const content = prefixContent ? prefixContent + '\n' + lastLineContent : lastLineContent;
+  // Keep the full value on a single content line so that @inquirer/core's
+  // screen manager can correctly compute the cursor position.  Manual wrapping
+  // broke the invariant that the last content line equals <prompt><rl.line>,
+  // which caused the cursor to drift one line below on wrap.  The screen
+  // manager's own breakLines() handles visual wrapping at terminal width.
+  const content = b('\u2502 ') + value;
 
   return [top + '\n' + content, bottom + (hint ? '\n' + hint : '') + suggestionContent];
 });


### PR DESCRIPTION
## Summary
- Removed manual text wrapping in `bordered-input.ts` that broke `@inquirer/core`'s screen manager cursor positioning
- The manual wrapping split the value across multiple content lines, violating the invariant that the last content line equals `<prompt><rl.line>` — this caused the cursor to appear one line below the actual input position when text exceeded the box width
- The screen manager's built-in `breakLines()` now handles visual wrapping at terminal width

## Risk tier
Tier 2 — UI component fix, no core engine or entry point changes.

## Files modified
- `src/ui/bordered-input.ts`

## Test results
- Lint: pass
- Typecheck: pass
- Tests: 138/138 pass
- Build: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)