### PR TITLE
fix: clear textarea text on double-ESC

### DIFF
--- a/src/ui/bordered-input.ts
+++ b/src/ui/bordered-input.ts
@@ -47,7 +47,7 @@ const _borderedInput = createPrompt<string, BorderedInputConfig>((config, done) 
     if (key.name === 'escape') {
       const now = Date.now();
       if (lastEscRef.current > 0 && now - lastEscRef.current < DOUBLE_ESC_MS) {
-        rl.write('\x15');
+        rl.line = '';
         setValue('');
         setSelectedIndex(0);
         lastEscRef.current = 0;
@@ -82,10 +82,8 @@ const _borderedInput = createPrompt<string, BorderedInputConfig>((config, done) 
         const selected = filtered[selectedIndex];
         if (selected) {
           const newValue = `/${selected.name}`;
-          // Clear current line by sending backspaces, then write the new value.
-          // We use the underlying readline's key simulation by writing the
-          // control character for kill-line (\x15 = Ctrl+U) followed by the value.
-          rl.write('\x15');
+          // Replace readline buffer with the new value.
+          rl.line = '';
           rl.write(newValue);
           setValue(newValue);
           setSelectedIndex(0);

--- a/tests/unit/bordered-input.test.ts
+++ b/tests/unit/bordered-input.test.ts
@@ -245,7 +245,7 @@ describe('bordered-input double-ESC clear behavior', () => {
     vi.spyOn(Date, 'now').mockReturnValue(now + 200);
     mockCtx.keypressHandler!({ name: 'escape' }, rl);
     expect(mockCtx.value).toBe('');
-    expect(write).toHaveBeenCalledWith('\x15');
+    expect(rl.line).toBe('');
     expect(mockCtx.lastEscRef.current).toBe(0);
 
     vi.restoreAllMocks();


### PR DESCRIPTION
## Summary

- **Root cause**: `rl.write('\x15')` does not get interpreted as Ctrl+U by Node's readline when called without a key object — the control character is either silently dropped or inserted as a literal, leaving `rl.line` unchanged.
- **Effect**: After double-ESC, `setValue('')` momentarily clears the display, but on the next keypress `setValue(rl.line.trim())` restores the old text from the uncleared readline buffer.
- **Fix**: Replace `rl.write('\x15')` with `rl.line = ''` to directly reset the readline buffer. Also fixes the same pattern in the tab-completion path.

**Risk tier**: Tier 2 — UI behavior fix, no critical paths changed.

## Files modified

- `src/ui/bordered-input.ts` — replace `rl.write('\x15')` with `rl.line = ''` in double-ESC and tab-completion handlers
- `tests/unit/bordered-input.test.ts` — update assertion to check `rl.line` directly instead of `write` call

## Test results

- 17 test files, 142 tests passed
- Lint: clean
- Typecheck: clean
- Build: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)