### PR TITLE
feat: ensure agent-pr label is used consistently across all PR creation routes

### DIFF
--- a/src/prompts/issue-implementer.ts
+++ b/src/prompts/issue-implementer.ts
@@ -141,10 +141,8 @@ When triggered via \`workflow_dispatch\` (issue mode):
 9. **PR creation**:
    - Stage all changes, commit: \`feat: implement #<issue-number> — <issue-title>\`
    - Push the branch
-   - Create a pull request:
-     - Title: \`feat: <issue-title>\`
-     - Body: summary + quality gates table + \`Closes #<issue-number>\` + \`<!-- issue-implementer: #<issue-number> -->\`
-     - Labels: \`agent-pr\`
+   - Create a pull request: \`gh pr create --label "agent-pr" --title "feat: <issue-title>" --body "..."\`
+     - Body must include: implementation summary, quality gates results table, \`Closes #<issue-number>\`, and \`<!-- issue-implementer: #<issue-number> -->\`
    - Comment on the issue: "PR created: <pr-url>"
 
 10. **Escalation (failure handler)**:

--- a/tests/unit/issue-implementer-prompt.test.ts
+++ b/tests/unit/issue-implementer-prompt.test.ts
@@ -1,0 +1,52 @@
+import { buildIssueImplementerPrompt } from '../../src/prompts/issue-implementer.js';
+import type { DetectionResult } from '../../src/core/detector.js';
+import type { UserPreferences } from '../../src/prompts/types.js';
+
+const baseDetection: DetectionResult = {
+  primaryLanguage: 'typescript',
+  languages: ['typescript'],
+  hasTypeScript: true,
+  framework: 'next',
+  packageManager: 'npm',
+  testFramework: 'vitest',
+  linter: 'eslint',
+  formatter: 'prettier',
+  typeChecker: 'tsc',
+  buildTool: 'tsup',
+  ciProvider: 'github-actions',
+  existingDocs: [],
+  existingClaude: false,
+  architecturalLayers: [],
+  monorepo: false,
+  testCommand: 'npm test',
+  buildCommand: 'npm run build',
+  lintCommand: 'npm run lint',
+  hasUIComponents: false,
+  criticalPaths: [],
+};
+
+const basePrefs: UserPreferences = {
+  ciProvider: 'github-actions',
+  strictnessLevel: 'standard',
+  selectedHarnesses: ['issue-implementer'],
+};
+
+describe('buildIssueImplementerPrompt', () => {
+  it('should include agent-pr label in gh pr create command', () => {
+    const result = buildIssueImplementerPrompt(baseDetection, basePrefs);
+    expect(result).toContain('--label "agent-pr"');
+  });
+
+  it('should use explicit gh pr create syntax for PR creation', () => {
+    const result = buildIssueImplementerPrompt(baseDetection, basePrefs);
+    expect(result).toContain('gh pr create --label "agent-pr"');
+  });
+
+  it('should mention agent-pr label for GitLab CI provider', () => {
+    const result = buildIssueImplementerPrompt(baseDetection, {
+      ...basePrefs,
+      ciProvider: 'gitlab-ci',
+    });
+    expect(result).toContain('agent-pr');
+  });
+});


### PR DESCRIPTION
## Summary

- Made the `--label "agent-pr"` flag explicit in the issue-implementer prompt's step 9 PR creation command, replacing the ambiguous "Labels: `agent-pr`" bullet point
- Added unit tests for `buildIssueImplementerPrompt` verifying the `agent-pr` label is present in the generated prompt output
- The `agent-system.ts` DEFAULT_TEMPLATE already contained `--label "agent-pr"` (commit `c2dd4ff`); this change ensures the same explicit instruction exists for the issue route

## Files Modified

- `src/prompts/issue-implementer.ts` — step 9 now instructs: `gh pr create --label "agent-pr" --title "..." --body "..."`
- `tests/unit/issue-implementer-prompt.test.ts` — new test file verifying label presence in the prompt

## How the label flows end-to-end

1. **`codefactory init`** — `src/commands/init.ts` creates the `agent-pr` GitHub label in the repo via `gh label create`
2. **Worktree agents** — `src/prompts/agent-system.ts` DEFAULT_TEMPLATE includes `--label "agent-pr"` in the "When You Are Done" section
3. **Issue route** — `src/prompts/issue-implementer.ts` step 9 now explicitly uses `gh pr create --label "agent-pr"` in the generated CI workflow

## Test Results

```
Test Files  18 passed (18)
     Tests  145 passed (145)
```

All quality gates: lint ✓ typecheck ✓ tests ✓ build ✓

## Risk Tier

Tier 1 — prompt template text change and new test. No changes to core engine, CLI entry points, or critical paths.