### PR TITLE
fix: rename npm package to codefactory-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ curl -fsSL https://raw.githubusercontent.com/yasha-dev1/codefactory/main/scripts
 ### npm
 
 ```bash
-npm install -g codefactory
+npm install -g codefactory-cli
 ```
 
 ### Manual

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "codefactory",
-  "version": "0.2.0",
+  "name": "codefactory-cli",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "codefactory",
-      "version": "0.2.0",
+      "name": "codefactory-cli",
+      "version": "0.2.4",
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "11.1.4",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "codefactory",
+  "name": "codefactory-cli",
   "version": "0.2.4",
   "description": "CLI tool that automates harness engineering setup for AI coding agents",
   "type": "module",


### PR DESCRIPTION
## Summary
- **Problem**: `npm install -g codefactory` installs a completely different, deprecated npm package (v0.1.2 by `lieene@shaderealm.com` — a VS Code extension). The name `codefactory` is already taken on the npm registry.
- **Fix**: Rename the npm package to `codefactory-cli` (available on npm). The `bin` field still exposes the `codefactory` command, so the CLI UX is unchanged.
- Updated `package.json`, `package-lock.json`, and README install instructions.

## Risk Tier
Tier 3 — changes `package.json` and `package-lock.json` (build infra).

## Test plan
- [ ] `npm run build` passes
- [ ] `npm run lint` passes
- [ ] `npm run typecheck` passes
- [ ] `npm test` passes
- [ ] Verify `npm install -g codefactory-cli` would install this package once published
- [ ] Verify the `codefactory` CLI command still works after install

🤖 Generated with [Claude Code](https://claude.com/claude-code)