### PR TITLE
feat: add FlowHunt branding to CLI startup

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -3,6 +3,7 @@ import { join, relative } from 'node:path';
 import { execFile, execFileSync } from 'node:child_process';
 import { promisify } from 'node:util';
 
+import { renderFlowHuntBranding } from '../ui/banner.js';
 import { logger } from '../ui/logger.js';
 import { withSpinner } from '../ui/spinner.js';
 import { confirmPrompt, selectPrompt, multiselectPrompt, inputPrompt } from '../ui/prompts.js';
@@ -62,6 +63,8 @@ export async function initCommand(options: InitOptions): Promise<void> {
 
   const repoRoot = await getRepoRoot();
 
+  console.log(renderFlowHuntBranding());
+  console.log();
   logger.header('CodeFactory - Harness Engineering Setup');
   logger.dim(
     'This wizard will analyze your repository and generate harness engineering artifacts.',

--- a/src/ui/banner.ts
+++ b/src/ui/banner.ts
@@ -9,6 +9,26 @@ const CF_LOGO_LINES = ['╔══╗ ╔═══', '║    ╠═══', '║ 
 
 const ACCENT = '#FF8C00'; // Orange, same aesthetic as Claude Code
 
+const FLOWHUNT_URL = 'https://www.flowhunt.io';
+
+export function supportsHyperlinks(stream: NodeJS.WriteStream = process.stdout): boolean {
+  if (process.env.FORCE_HYPERLINK === '1') return true;
+  if (process.env.NO_COLOR) return false;
+  if (process.env.TERM === 'dumb') return false;
+  return Boolean(stream.isTTY);
+}
+
+function osc8Link(url: string, text: string): string {
+  // OSC 8 hyperlink: ESC ] 8 ;; URL ST text ESC ] 8 ;; ST
+  return `\x1b]8;;${url}\x1b\\${text}\x1b]8;;\x1b\\`;
+}
+
+export function renderFlowHuntBranding(opts: { hyperlinks?: boolean } = {}): string {
+  const hyperlinks = opts.hyperlinks ?? supportsHyperlinks();
+  const link = hyperlinks ? osc8Link(FLOWHUNT_URL, FLOWHUNT_URL) : FLOWHUNT_URL;
+  return `${chalk.bold('FlowHunt')}${chalk.dim(' — powered by flowhunt · ')}${chalk.dim(link)}`;
+}
+
 export function printBanner(): void {
   const hr = chalk.dim('─'.repeat(58));
 
@@ -32,6 +52,8 @@ export function printBanner(): void {
     }
   });
 
+  console.log();
+  console.log(`  ${renderFlowHuntBranding()}`);
   console.log();
   console.log(`  ${chalk.dim('Type a task to start a new worktree session')}`);
   console.log(

--- a/tests/unit/banner.test.ts
+++ b/tests/unit/banner.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { renderFlowHuntBranding, supportsHyperlinks } from '../../src/ui/banner.js';
+
+const FLOWHUNT_URL = 'https://www.flowhunt.io';
+const OSC8_PREFIX = `\x1b]8;;${FLOWHUNT_URL}\x1b\\`;
+const OSC8_TERMINATOR = '\x1b]8;;\x1b\\';
+
+// Strip ANSI styling so we can assert on the plain content regardless of chalk state.
+function stripAnsi(s: string): string {
+  // eslint-disable-next-line no-control-regex
+  return s.replace(/\x1b\[[0-9;]*m/g, '');
+}
+
+describe('renderFlowHuntBranding', () => {
+  const savedEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...savedEnv };
+  });
+
+  it('contains the FlowHunt name, tagline, and URL in plain-text mode', () => {
+    const out = stripAnsi(renderFlowHuntBranding({ hyperlinks: false }));
+    expect(out).toContain('FlowHunt');
+    expect(out).toContain('powered by flowhunt');
+    expect(out).toContain(FLOWHUNT_URL);
+    expect(out).not.toContain('\x1b]8;;');
+  });
+
+  it('wraps the URL in an OSC 8 hyperlink sequence when hyperlinks are enabled', () => {
+    const out = renderFlowHuntBranding({ hyperlinks: true });
+    expect(out).toContain(OSC8_PREFIX);
+    expect(out).toContain(OSC8_TERMINATOR);
+    expect(stripAnsi(out)).toContain(FLOWHUNT_URL);
+  });
+
+  it('respects NO_COLOR by emitting no chalk escape codes while keeping the URL text', () => {
+    process.env.NO_COLOR = '1';
+    const out = renderFlowHuntBranding({ hyperlinks: false });
+    expect(out).toContain('FlowHunt');
+    expect(out).toContain(FLOWHUNT_URL);
+    // chalk disables styling under NO_COLOR, so no SGR escape codes should appear
+    // eslint-disable-next-line no-control-regex
+    expect(out).not.toMatch(/\x1b\[[0-9;]*m/);
+  });
+});
+
+describe('supportsHyperlinks', () => {
+  const savedEnv = { ...process.env };
+
+  beforeEach(() => {
+    delete process.env.FORCE_HYPERLINK;
+    delete process.env.NO_COLOR;
+    delete process.env.TERM;
+  });
+
+  afterEach(() => {
+    process.env = { ...savedEnv };
+  });
+
+  it('returns true when FORCE_HYPERLINK=1 regardless of TTY', () => {
+    process.env.FORCE_HYPERLINK = '1';
+    expect(supportsHyperlinks({ isTTY: false } as NodeJS.WriteStream)).toBe(true);
+  });
+
+  it('returns false when NO_COLOR is set', () => {
+    process.env.NO_COLOR = '1';
+    expect(supportsHyperlinks({ isTTY: true } as NodeJS.WriteStream)).toBe(false);
+  });
+
+  it('returns false when TERM=dumb', () => {
+    process.env.TERM = 'dumb';
+    expect(supportsHyperlinks({ isTTY: true } as NodeJS.WriteStream)).toBe(false);
+  });
+
+  it('returns false when stream is not a TTY', () => {
+    expect(supportsHyperlinks({ isTTY: false } as NodeJS.WriteStream)).toBe(false);
+  });
+
+  it('returns true for a TTY stream with no inhibiting env vars', () => {
+    expect(supportsHyperlinks({ isTTY: true } as NodeJS.WriteStream)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a `FlowHunt — powered by flowhunt · https://www.flowhunt.io` attribution line to the CLI startup surfaces.
- Renders in the REPL banner (via `printBanner()` in `src/ui/banner.ts`) and once at the top of the non-interactive `init` flow.
- URL is emitted as an OSC 8 terminal hyperlink where supported (checks `FORCE_HYPERLINK`, `NO_COLOR`, `TERM=dumb`, TTY); falls back to plain text otherwise.
- Uses the existing `chalk` dependency for styling — no new dependencies.

## Implementation notes

The issue body referenced `packages/cli/src/modes/interactive/` and `packages/cli/src/modes/print-mode.ts`, which don't exist in this flat `src/` layout. Per the plan comment, the targeted surfaces are:

- `src/ui/banner.ts` — REPL banner (used by `src/commands/repl.ts`).
- `src/commands/init.ts` — the closest analogue to a one-shot entry point; no `-p/--prompt` mode exists in this CLI.

`renderFlowHuntBranding()` is a pure string returner, which keeps the unit test deterministic. `supportsHyperlinks()` is exported for test injection.

## Risk

- Tier 3: `src/commands/init.ts` is listed as a critical path in `CLAUDE.md` (two-line addition — branding print only).
- All other changes are presentation-only.

## Test plan

- [x] `npm run typecheck` — clean.
- [x] `npm run lint` — no new errors (2 pre-existing warnings unchanged).
- [x] `npm test` — 316 tests pass, including 8 new cases in `tests/unit/banner.test.ts`:
  - plain-text fallback content
  - OSC 8 sequence shape when hyperlinks enabled
  - `NO_COLOR` respected (no SGR escapes)
  - `supportsHyperlinks` honors `FORCE_HYPERLINK`, `NO_COLOR`, `TERM=dumb`, and TTY flag

closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)