### PR TITLE
feat: add FlowHunt branding to CLI startup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codefactory-cli",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codefactory-cli",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "11.1.4",

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -4,6 +4,7 @@ import { execFile, execFileSync } from 'node:child_process';
 import { promisify } from 'node:util';
 
 import { logger } from '../ui/logger.js';
+import { printFlowHuntBranding } from '../ui/branding.js';
 import { withSpinner } from '../ui/spinner.js';
 import { confirmPrompt, selectPrompt, multiselectPrompt, inputPrompt } from '../ui/prompts.js';
 import { isGitRepo, getRepoRoot } from '../utils/git.js';
@@ -61,6 +62,9 @@ export async function initCommand(options: InitOptions): Promise<void> {
   }
 
   const repoRoot = await getRepoRoot();
+
+  printFlowHuntBranding();
+  console.log();
 
   logger.header('CodeFactory - Harness Engineering Setup');
   logger.dim(

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -9,6 +9,7 @@ import { Readable } from 'node:stream';
 import chalk from 'chalk';
 
 import { logger } from '../ui/logger.js';
+import { printFlowHuntBranding } from '../ui/branding.js';
 import { withSpinner } from '../ui/spinner.js';
 import { ChecksumError, NetworkError, UpdateError } from '../utils/errors.js';
 import { getPackageInfo } from '../utils/package-info.js';
@@ -16,6 +17,9 @@ import { checkForUpdate } from '../utils/version-check.js';
 
 export async function updateCommand(options: { check?: boolean; force?: boolean }): Promise<void> {
   const { version: currentVersion } = getPackageInfo();
+
+  printFlowHuntBranding();
+  console.log();
 
   try {
     const { available, latest } = await checkForUpdate(currentVersion);

--- a/src/ui/banner.ts
+++ b/src/ui/banner.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk';
 
 import { getPackageInfo } from '../utils/package-info.js';
+import { renderFlowHuntBranding } from './branding.js';
 
 const pkg = getPackageInfo();
 
@@ -32,6 +33,8 @@ export function printBanner(): void {
     }
   });
 
+  console.log();
+  console.log(`  ${renderFlowHuntBranding()}`);
   console.log();
   console.log(`  ${chalk.dim('Type a task to start a new worktree session')}`);
   console.log(

--- a/src/ui/branding.ts
+++ b/src/ui/branding.ts
@@ -1,0 +1,42 @@
+import chalk from 'chalk';
+
+const FLOWHUNT_URL = 'https://www.flowhunt.io';
+
+function supportsHyperlinks(): boolean {
+  if (!process.stdout.isTTY) return false;
+
+  const term = process.env.TERM ?? '';
+  if (term === 'dumb') return false;
+
+  const termProgram = process.env.TERM_PROGRAM ?? '';
+  if (
+    termProgram === 'iTerm.app' ||
+    termProgram === 'WezTerm' ||
+    termProgram === 'ghostty' ||
+    termProgram === 'vscode'
+  ) {
+    return true;
+  }
+
+  if (process.env.VTE_VERSION) return true;
+  if (process.env.KITTY_WINDOW_ID) return true;
+  if (process.env.WT_SESSION) return true;
+
+  return false;
+}
+
+export function hyperlink(url: string, label: string): string {
+  if (!supportsHyperlinks()) return label === url ? url : `${label} (${url})`;
+  return `\x1b]8;;${url}\x07${label}\x1b]8;;\x07`;
+}
+
+export function renderFlowHuntBranding(): string {
+  const name = chalk.bold('FlowHunt');
+  const tagline = chalk.dim(' — powered by flowhunt · ');
+  const link = chalk.dim(hyperlink(FLOWHUNT_URL, FLOWHUNT_URL));
+  return `${name}${tagline}${link}`;
+}
+
+export function printFlowHuntBranding(): void {
+  console.log(renderFlowHuntBranding());
+}

--- a/tests/unit/branding.test.ts
+++ b/tests/unit/branding.test.ts
@@ -1,0 +1,120 @@
+import chalk from 'chalk';
+
+import { hyperlink, renderFlowHuntBranding } from '../../src/ui/branding.js';
+
+const URL = 'https://www.flowhunt.io';
+const OSC8 = '\x1b]8;;';
+
+describe('hyperlink', () => {
+  const originalIsTTY = process.stdout.isTTY;
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.TERM_PROGRAM;
+    delete process.env.VTE_VERSION;
+    delete process.env.KITTY_WINDOW_ID;
+    delete process.env.WT_SESSION;
+  });
+
+  afterEach(() => {
+    process.stdout.isTTY = originalIsTTY;
+    process.env = originalEnv;
+  });
+
+  it('falls back to plain text when not a TTY', () => {
+    process.stdout.isTTY = false;
+    const out = hyperlink(URL, URL);
+    expect(out).toBe(URL);
+    expect(out).not.toContain(OSC8);
+  });
+
+  it('falls back to plain text when TERM is dumb', () => {
+    process.stdout.isTTY = true;
+    process.env.TERM = 'dumb';
+    const out = hyperlink(URL, URL);
+    expect(out).toBe(URL);
+    expect(out).not.toContain(OSC8);
+  });
+
+  it('includes URL in parentheses when label differs and no hyperlink support', () => {
+    process.stdout.isTTY = false;
+    const out = hyperlink(URL, 'FlowHunt');
+    expect(out).toBe(`FlowHunt (${URL})`);
+  });
+
+  it('emits OSC 8 hyperlink when TERM_PROGRAM is iTerm.app', () => {
+    process.stdout.isTTY = true;
+    process.env.TERM_PROGRAM = 'iTerm.app';
+    const out = hyperlink(URL, URL);
+    expect(out).toContain(OSC8);
+    expect(out).toContain(URL);
+    expect(out).toBe(`\x1b]8;;${URL}\x07${URL}\x1b]8;;\x07`);
+  });
+
+  it('emits OSC 8 hyperlink when VTE_VERSION is set', () => {
+    process.stdout.isTTY = true;
+    process.env.VTE_VERSION = '6200';
+    const out = hyperlink(URL, URL);
+    expect(out).toContain(OSC8);
+  });
+});
+
+describe('renderFlowHuntBranding', () => {
+  const originalLevel = chalk.level;
+  const originalIsTTY = process.stdout.isTTY;
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    chalk.level = 1;
+    process.env = { ...originalEnv };
+    delete process.env.TERM_PROGRAM;
+    delete process.env.VTE_VERSION;
+    delete process.env.KITTY_WINDOW_ID;
+    delete process.env.WT_SESSION;
+  });
+
+  afterEach(() => {
+    chalk.level = originalLevel;
+    process.stdout.isTTY = originalIsTTY;
+    process.env = originalEnv;
+  });
+
+  it('includes the FlowHunt name', () => {
+    process.stdout.isTTY = false;
+    const out = renderFlowHuntBranding();
+    expect(out).toContain('FlowHunt');
+  });
+
+  it('includes the tagline', () => {
+    process.stdout.isTTY = false;
+    const out = renderFlowHuntBranding();
+    expect(out).toContain('powered by flowhunt');
+  });
+
+  it('renders FlowHunt name with bold chalk styling', () => {
+    process.stdout.isTTY = false;
+    const out = renderFlowHuntBranding();
+    expect(out).toContain(chalk.bold('FlowHunt'));
+  });
+
+  it('renders the URL exactly once', () => {
+    process.stdout.isTTY = false;
+    const out = renderFlowHuntBranding();
+    const matches = out.match(/https:\/\/www\.flowhunt\.io/g) ?? [];
+    expect(matches).toHaveLength(1);
+  });
+
+  it('omits OSC 8 escape when not hyperlink-capable', () => {
+    process.stdout.isTTY = false;
+    const out = renderFlowHuntBranding();
+    expect(out).not.toContain(OSC8);
+  });
+
+  it('emits OSC 8 escape when hyperlink-capable', () => {
+    process.stdout.isTTY = true;
+    process.env.TERM_PROGRAM = 'iTerm.app';
+    const out = renderFlowHuntBranding();
+    expect(out).toContain(OSC8);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a FlowHunt credit line (**FlowHunt** — powered by flowhunt · https://www.flowhunt.io) to the CLI startup so every session visibly credits the underlying infrastructure.

- New `src/ui/branding.ts` with `renderFlowHuntBranding()` and a tiny OSC 8 hyperlink helper (plain-text fallback when the terminal does not advertise hyperlink support).
- Wired into `printBanner()` (REPL) and the top of `initCommand` / `updateCommand` (non-REPL entry points).
- Uses existing `chalk` — no new dependencies.

> Note on the issue's `harnext -p --prompt "..."` one-shot mode: codefactory does not have a `-p` print mode, so the equivalent non-REPL surfaces (`init`, `update`) carry the branding, matching the plan's option (b).

## Risk tier

**Tier 2** — cosmetic UI only. No changes to `harness.config.json`, core engine, or architectural boundaries.

## Test plan

- [x] `npm test` — 319 tests passing, including 11 new branding tests
- [x] `npm run lint` — clean (2 pre-existing warnings unrelated to this change)
- [x] `npm run typecheck` — passes
- [x] `npm run build` — builds cleanly
- [ ] Manual smoke: REPL banner shows the line; link is clickable in iTerm2/WezTerm/Kitty
- [ ] Manual smoke: `codefactory init` / `codefactory update` show the line once at the top
- [ ] Manual smoke: piping to `| cat` produces plain-text URL, no escape bytes

closes #60