### PR TITLE
feat: add `setup` command with multi-coding-agent support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codefactory-cli",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codefactory-cli",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "11.1.4",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -37,6 +37,35 @@ program
   );
 
 program
+  .command('setup')
+  .description(
+    'Set up CodeFactory in this repo, including a coding-agent picker (harnext, claude-code, codex)',
+  )
+  .option('--coding-agent <id>', 'Coding agent: harnext, claude-code, or codex')
+  .option('--model <id>', 'Model id for the chosen coding agent (non-harnext only)')
+  .option('--skip-detection', 'Skip Claude analysis, use heuristics only')
+  .option('--dry-run', 'Show what would be generated without writing files')
+  .option('--platform <platform>', 'AI platform: claude, kiro, or codex')
+  .option('--ci-provider <provider>', 'CI provider: github-actions, gitlab-ci, or bitbucket')
+  .option('--strictness <level>', 'Strictness level: relaxed, standard, or strict')
+  .option('-y, --yes', 'Accept all defaults non-interactively')
+  .action(
+    async (options: {
+      codingAgent?: string;
+      model?: string;
+      skipDetection?: boolean;
+      dryRun?: boolean;
+      platform?: string;
+      ciProvider?: string;
+      strictness?: string;
+      yes?: boolean;
+    }) => {
+      const { setupCommand } = await import('./commands/setup.js');
+      await setupCommand(options);
+    },
+  );
+
+program
   .command('update')
   .description('Check for and install updates')
   .option('--check', 'Check for updates without installing')

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -111,12 +111,16 @@ export async function initCommand(options: InitOptions): Promise<void> {
         { name: 'Bitbucket Pipelines', value: 'bitbucket' },
       ]);
 
-  const aiPlatform = nonInteractive
-    ? ((options.platform ?? 'claude') as AIPlatform)
-    : await selectPrompt<AIPlatform>(
-        'Which AI coding agent do you use?',
-        AI_PLATFORMS.map((p) => ({ name: `${p.name} — ${p.description}`, value: p.value })),
-      );
+  // If a caller (e.g. `setup` for a non-harnext coding agent) preselected
+  // the platform, honour it and skip the prompt even in interactive mode.
+  const aiPlatform: AIPlatform = options.platform
+    ? (options.platform as AIPlatform)
+    : nonInteractive
+      ? 'claude'
+      : await selectPrompt<AIPlatform>(
+          'Which AI coding agent do you use?',
+          AI_PLATFORMS.map((p) => ({ name: `${p.name} — ${p.description}`, value: p.value })),
+        );
 
   // Validate CLI availability
   try {

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -1,0 +1,144 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { logger } from '../ui/logger.js';
+import { selectPrompt } from '../ui/prompts.js';
+import { isGitRepo, getRepoRoot } from '../utils/git.js';
+import { NotAGitRepoError } from '../utils/errors.js';
+import {
+  CODING_AGENTS,
+  CODING_AGENT_IDS,
+  isCodingAgentId,
+  type CodingAgentId,
+  type CodingAgentSpec,
+} from '../core/coding-agent-registry.js';
+import { initCommand, type InitOptions } from './init.js';
+
+export interface SetupOptions extends InitOptions {
+  codingAgent?: string;
+  model?: string;
+}
+
+// Maps a non-harnext coding agent to the AI platform string the underlying
+// init/runner pipeline already understands. `harnext` keeps its existing
+// model/provider picker, so it has no entry here.
+const CODING_AGENT_TO_PLATFORM: Record<Exclude<CodingAgentId, 'harnext'>, string> = {
+  'claude-code': 'claude',
+  codex: 'codex',
+};
+
+export async function setupCommand(options: SetupOptions): Promise<void> {
+  if (!(await isGitRepo())) {
+    throw new NotAGitRepoError();
+  }
+
+  const repoRoot = await getRepoRoot();
+
+  logger.header('CodeFactory - Setup');
+  logger.dim('Choose a coding agent for this project, then walk through the harness setup wizard.');
+  console.log();
+
+  const agentId = await resolveCodingAgent(options);
+  const agent = CODING_AGENTS[agentId];
+
+  logger.info(`Coding agent: ${agent.displayName}`);
+  console.log();
+
+  if (agentId === 'harnext') {
+    // Harnext keeps its existing model/provider picker — delegate verbatim.
+    await initCommand(stripSetupOnlyOptions(options));
+    return;
+  }
+
+  // Non-harnext agent: pick a model from the registry, then run the
+  // standard onboarding with the AI platform pre-selected so init's
+  // model/provider picker is skipped.
+  const model = await resolveModel(agent, options.model);
+
+  const initOpts: InitOptions = {
+    ...stripSetupOnlyOptions(options),
+    platform: CODING_AGENT_TO_PLATFORM[agentId],
+  };
+
+  await initCommand(initOpts);
+
+  await persistCodingAgent(repoRoot, agentId, model);
+
+  console.log();
+  logger.success(
+    `Saved coding agent "${agent.displayName}" (model: ${model}) to harness.config.json.`,
+  );
+  logger.dim(`Pipeline runners will invoke: ${agent.binary} ${agent.modelFlag} ${model}`);
+}
+
+async function resolveCodingAgent(options: SetupOptions): Promise<CodingAgentId> {
+  if (options.codingAgent) {
+    if (!isCodingAgentId(options.codingAgent)) {
+      throw new Error(
+        `Unknown coding agent "${options.codingAgent}". Expected one of: ${CODING_AGENT_IDS.join(', ')}.`,
+      );
+    }
+    return options.codingAgent;
+  }
+
+  if (options.yes) {
+    return 'harnext';
+  }
+
+  return selectPrompt<CodingAgentId>(
+    'Which coding agent should drive this project?',
+    CODING_AGENT_IDS.map((id) => ({
+      name: `${CODING_AGENTS[id].displayName} — ${CODING_AGENTS[id].description}`,
+      value: id,
+    })),
+  );
+}
+
+async function resolveModel(
+  agent: CodingAgentSpec,
+  requested: string | undefined,
+): Promise<string> {
+  if (requested) {
+    if (!agent.supportedModels.includes(requested)) {
+      logger.warn(
+        `Model "${requested}" is not in the registry's supported list for ${agent.displayName}. Using it anyway.`,
+      );
+    }
+    return requested;
+  }
+
+  return selectPrompt<string>(
+    `Select a model for ${agent.displayName}:`,
+    agent.supportedModels.map((m) => ({
+      name: m === agent.defaultModel ? `${m} (default)` : m,
+      value: m,
+    })),
+  );
+}
+
+async function persistCodingAgent(
+  repoRoot: string,
+  agentId: CodingAgentId,
+  model: string,
+): Promise<void> {
+  const configPath = join(repoRoot, 'harness.config.json');
+
+  let config: Record<string, unknown> = {};
+  try {
+    const raw = await readFile(configPath, 'utf-8');
+    config = JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    // No existing config (e.g. user aborted init before harness.config.json
+    // was written). Persist a minimal stub so the choice is not lost.
+  }
+
+  config.codingAgent = { id: agentId, model };
+  config.lastUpdated = new Date().toISOString();
+
+  await writeFile(configPath, JSON.stringify(config, null, 2) + '\n', 'utf-8');
+}
+
+function stripSetupOnlyOptions(options: SetupOptions): InitOptions {
+  const { codingAgent: _codingAgent, model: _model, ...initOpts } = options;
+  return initOpts;
+}

--- a/src/core/coding-agent-registry.ts
+++ b/src/core/coding-agent-registry.ts
@@ -1,0 +1,64 @@
+// Single source of truth for the coding agents the harness can drive.
+// Pipeline runners and the `setup` command both import from here so a new
+// agent only has to be added in one place.
+//
+// `supportedModels` lists are hardcoded snapshots of vendor-published model
+// IDs; dynamic probing is intentionally out of scope (issue #49). See:
+//   - Claude Code: https://support.claude.com/en/articles/11940350-claude-code-model-configuration
+//   - Codex CLI:   https://developers.openai.com/codex/models
+
+export type CodingAgentId = 'harnext' | 'claude-code' | 'codex';
+
+export interface CodingAgentSpec {
+  id: CodingAgentId;
+  displayName: string;
+  description: string;
+  binary: string;
+  modelFlag: string;
+  supportedModels: string[];
+  defaultModel: string;
+}
+
+export const CODING_AGENTS: Record<CodingAgentId, CodingAgentSpec> = {
+  harnext: {
+    id: 'harnext',
+    displayName: 'harnext',
+    description: 'CodeFactory/harnext native agent (uses configured AI platform)',
+    binary: 'codefactory',
+    modelFlag: '-m',
+    supportedModels: ['claude-opus-4-7', 'claude-sonnet-4-6', 'claude-haiku-4-5-20251001'],
+    defaultModel: 'claude-sonnet-4-6',
+  },
+  'claude-code': {
+    id: 'claude-code',
+    displayName: 'Claude Code',
+    description: 'Anthropic Claude Code CLI — claude',
+    binary: 'claude',
+    modelFlag: '--model',
+    supportedModels: ['claude-opus-4-7', 'claude-sonnet-4-6', 'claude-haiku-4-5-20251001'],
+    defaultModel: 'claude-sonnet-4-6',
+  },
+  codex: {
+    id: 'codex',
+    displayName: 'OpenAI Codex',
+    description: 'OpenAI Codex CLI — codex',
+    binary: 'codex',
+    modelFlag: '--model',
+    supportedModels: ['gpt-5.4', 'gpt-5.4-mini', 'gpt-5-codex'],
+    defaultModel: 'gpt-5.4',
+  },
+};
+
+export const CODING_AGENT_IDS: CodingAgentId[] = Object.keys(CODING_AGENTS) as CodingAgentId[];
+
+export function getCodingAgent(id: CodingAgentId): CodingAgentSpec {
+  return CODING_AGENTS[id];
+}
+
+export function listSupportedModels(id: CodingAgentId): string[] {
+  return CODING_AGENTS[id].supportedModels;
+}
+
+export function isCodingAgentId(value: unknown): value is CodingAgentId {
+  return typeof value === 'string' && value in CODING_AGENTS;
+}

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,6 +1,7 @@
 import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 import { fileExists } from '../utils/fs.js';
+import type { CodingAgentId } from './coding-agent-registry.js';
 
 export interface HarnessConfig {
   version: string;
@@ -18,6 +19,15 @@ export interface HarnessConfig {
     generatedAt: string;
     files: string[];
   }[];
+  /**
+   * Persisted by `codefactory setup`. When pipeline runners are wired up
+   * (follow-up to issue #49) they read this field to decide which CLI to
+   * spawn and which `--model` value to pass.
+   */
+  codingAgent?: {
+    id: CodingAgentId;
+    model: string;
+  };
   generatedAt: string;
   lastUpdated: string;
 }

--- a/tests/unit/coding-agent-registry.test.ts
+++ b/tests/unit/coding-agent-registry.test.ts
@@ -1,0 +1,57 @@
+import {
+  CODING_AGENTS,
+  CODING_AGENT_IDS,
+  getCodingAgent,
+  isCodingAgentId,
+  listSupportedModels,
+} from '../../src/core/coding-agent-registry.js';
+
+describe('coding-agent registry', () => {
+  it('contains exactly the three agent ids from the issue scope', () => {
+    expect(CODING_AGENT_IDS.sort()).toEqual(['claude-code', 'codex', 'harnext']);
+  });
+
+  it('uses each vendor’s real binary name', () => {
+    expect(CODING_AGENTS['claude-code'].binary).toBe('claude');
+    expect(CODING_AGENTS['codex'].binary).toBe('codex');
+    expect(CODING_AGENTS['harnext'].binary).toBe('codefactory');
+  });
+
+  it('uses the model flag documented in each vendor’s CLI reference', () => {
+    expect(CODING_AGENTS['claude-code'].modelFlag).toBe('--model');
+    expect(CODING_AGENTS['codex'].modelFlag).toBe('--model');
+    expect(CODING_AGENTS['harnext'].modelFlag).toBe('-m');
+  });
+
+  it('every entry exposes a non-empty supportedModels list containing its defaultModel', () => {
+    for (const id of CODING_AGENT_IDS) {
+      const spec = CODING_AGENTS[id];
+      expect(spec.supportedModels.length).toBeGreaterThan(0);
+      expect(spec.supportedModels).toContain(spec.defaultModel);
+      for (const model of spec.supportedModels) {
+        expect(typeof model).toBe('string');
+        expect(model.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('getCodingAgent returns the matching spec', () => {
+    expect(getCodingAgent('codex').binary).toBe('codex');
+    expect(getCodingAgent('claude-code').displayName).toBe('Claude Code');
+  });
+
+  it('listSupportedModels mirrors the registry entry', () => {
+    const claudeModels = listSupportedModels('claude-code');
+    expect(claudeModels).toBe(CODING_AGENTS['claude-code'].supportedModels);
+  });
+
+  it('isCodingAgentId narrows known ids and rejects unknown values', () => {
+    expect(isCodingAgentId('harnext')).toBe(true);
+    expect(isCodingAgentId('claude-code')).toBe(true);
+    expect(isCodingAgentId('codex')).toBe(true);
+    expect(isCodingAgentId('cursor')).toBe(false);
+    expect(isCodingAgentId('')).toBe(false);
+    expect(isCodingAgentId(undefined)).toBe(false);
+    expect(isCodingAgentId(42)).toBe(false);
+  });
+});

--- a/tests/unit/setup-command.test.ts
+++ b/tests/unit/setup-command.test.ts
@@ -1,0 +1,160 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+// All external collaborators are mocked so the unit under test is purely
+// the routing/persistence logic in setup.ts.
+
+vi.mock('../../src/ui/logger.js', () => ({
+  logger: {
+    header: vi.fn(),
+    dim: vi.fn(),
+    info: vi.fn(),
+    success: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('../../src/ui/prompts.js', () => ({
+  selectPrompt: vi.fn(),
+  confirmPrompt: vi.fn(),
+  inputPrompt: vi.fn(),
+  multiselectPrompt: vi.fn(),
+}));
+
+vi.mock('../../src/utils/git.js', () => ({
+  isGitRepo: vi.fn(),
+  getRepoRoot: vi.fn(),
+}));
+
+vi.mock('../../src/commands/init.js', () => ({
+  initCommand: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>();
+  return {
+    ...actual,
+    readFile: vi.fn(),
+    writeFile: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+import { readFile, writeFile } from 'node:fs/promises';
+import { isGitRepo, getRepoRoot } from '../../src/utils/git.js';
+import { selectPrompt } from '../../src/ui/prompts.js';
+import { initCommand } from '../../src/commands/init.js';
+import { setupCommand } from '../../src/commands/setup.js';
+import { NotAGitRepoError } from '../../src/utils/errors.js';
+
+const mockedIsGitRepo = vi.mocked(isGitRepo);
+const mockedGetRepoRoot = vi.mocked(getRepoRoot);
+const mockedSelectPrompt = vi.mocked(selectPrompt);
+const mockedInitCommand = vi.mocked(initCommand);
+const mockedReadFile = vi.mocked(readFile);
+const mockedWriteFile = vi.mocked(writeFile);
+
+describe('setupCommand', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedIsGitRepo.mockResolvedValue(true);
+    mockedGetRepoRoot.mockResolvedValue('/fake/repo');
+    mockedReadFile.mockResolvedValue('{}');
+  });
+
+  it('throws NotAGitRepoError when invoked outside a git repo', async () => {
+    mockedIsGitRepo.mockResolvedValue(false);
+    await expect(setupCommand({})).rejects.toThrow(NotAGitRepoError);
+  });
+
+  it('delegates to initCommand without preset platform when harnext is selected', async () => {
+    mockedSelectPrompt.mockResolvedValueOnce('harnext');
+
+    await setupCommand({});
+
+    expect(mockedInitCommand).toHaveBeenCalledTimes(1);
+    const opts = mockedInitCommand.mock.calls[0][0];
+    expect(opts.platform).toBeUndefined();
+    // Should not have written codingAgent for harnext.
+    expect(mockedWriteFile).not.toHaveBeenCalled();
+  });
+
+  it('preselects the claude platform and persists codingAgent for claude-code', async () => {
+    // 1st prompt: agent picker, 2nd prompt: model picker.
+    mockedSelectPrompt
+      .mockResolvedValueOnce('claude-code')
+      .mockResolvedValueOnce('claude-sonnet-4-6');
+
+    await setupCommand({});
+
+    expect(mockedInitCommand).toHaveBeenCalledTimes(1);
+    expect(mockedInitCommand.mock.calls[0][0].platform).toBe('claude');
+
+    expect(mockedWriteFile).toHaveBeenCalledTimes(1);
+    const [path, body] = mockedWriteFile.mock.calls[0];
+    expect(String(path)).toMatch(/harness\.config\.json$/);
+    const written = JSON.parse(String(body)) as Record<string, unknown>;
+    expect(written.codingAgent).toEqual({
+      id: 'claude-code',
+      model: 'claude-sonnet-4-6',
+    });
+    expect(typeof written.lastUpdated).toBe('string');
+  });
+
+  it('preselects the codex platform and persists codingAgent for codex', async () => {
+    mockedSelectPrompt.mockResolvedValueOnce('codex').mockResolvedValueOnce('gpt-5.4');
+
+    await setupCommand({});
+
+    expect(mockedInitCommand.mock.calls[0][0].platform).toBe('codex');
+
+    const written = JSON.parse(String(mockedWriteFile.mock.calls[0][1])) as Record<string, unknown>;
+    expect(written.codingAgent).toEqual({ id: 'codex', model: 'gpt-5.4' });
+  });
+
+  it('preserves existing harness.config.json fields when persisting codingAgent', async () => {
+    mockedReadFile.mockResolvedValue(
+      JSON.stringify({ version: '1.0.0', riskTiers: { tier1: { name: 'low' } } }),
+    );
+    mockedSelectPrompt.mockResolvedValueOnce('codex').mockResolvedValueOnce('gpt-5.4');
+
+    await setupCommand({});
+
+    const written = JSON.parse(String(mockedWriteFile.mock.calls[0][1])) as Record<string, unknown>;
+    expect(written.version).toBe('1.0.0');
+    expect(written.riskTiers).toEqual({ tier1: { name: 'low' } });
+    expect(written.codingAgent).toEqual({ id: 'codex', model: 'gpt-5.4' });
+  });
+
+  it('respects --coding-agent and --model flags without prompting', async () => {
+    await setupCommand({ codingAgent: 'claude-code', model: 'claude-opus-4-7' });
+
+    expect(mockedSelectPrompt).not.toHaveBeenCalled();
+    expect(mockedInitCommand.mock.calls[0][0].platform).toBe('claude');
+    const written = JSON.parse(String(mockedWriteFile.mock.calls[0][1])) as Record<string, unknown>;
+    expect(written.codingAgent).toEqual({
+      id: 'claude-code',
+      model: 'claude-opus-4-7',
+    });
+  });
+
+  it('rejects an unknown coding agent id passed via --coding-agent', async () => {
+    await expect(setupCommand({ codingAgent: 'cursor' })).rejects.toThrow(/Unknown coding agent/);
+    expect(mockedInitCommand).not.toHaveBeenCalled();
+  });
+
+  it('does not leak the codingAgent or model options into initCommand', async () => {
+    await setupCommand({
+      codingAgent: 'claude-code',
+      model: 'claude-sonnet-4-6',
+      ciProvider: 'github-actions',
+      yes: true,
+    });
+
+    const opts = mockedInitCommand.mock.calls[0][0] as Record<string, unknown>;
+    expect(opts).not.toHaveProperty('codingAgent');
+    expect(opts).not.toHaveProperty('model');
+    expect(opts.ciProvider).toBe('github-actions');
+    expect(opts.yes).toBe(true);
+    expect(opts.platform).toBe('claude');
+  });
+});


### PR DESCRIPTION
## Summary

- New `codefactory setup` subcommand prepends a coding-agent picker (`harnext` | `claude-code` | `codex`) to the existing onboarding flow.
- New `src/core/coding-agent-registry.ts` is the single source of truth for each agent's binary, model flag, default model, and supported model list — both `setup` and future pipeline runners import from it.
- For `harnext`, `setup` delegates to `initCommand` unchanged. For `claude-code` / `codex` it pre-selects the matching AI platform (so `init`'s model/provider picker is skipped), prompts for a model from the registry, and persists `codingAgent: { id, model }` into `harness.config.json` for downstream pipeline work.
- `HarnessConfig` gains an optional `codingAgent` field (additive, backward-compatible).
- `init` now honours a preset `--platform` outside of non-interactive mode so `setup` can pre-select it without forcing `--yes`. No behavior change when `--platform` is omitted.

closes #49

## Risk tier

Tier 3: touches `src/cli.ts`, `src/commands/init.ts`, and `src/core/config.ts` — needs lint + type-check + test + review-agent + manual review.

## Test plan

- [x] `npm run lint` clean (only pre-existing warnings).
- [x] `npm run typecheck` clean.
- [x] `npm test` — 323 passing across 33 files (7 new registry tests + 7 new setup-command tests).
- [x] `npm run build` succeeds.
- [x] `node dist/index.js setup --help` prints the new command surface (`--coding-agent`, `--model`, plus the existing init flags).
- [ ] Manual smoke in a fresh clone: walk each of the three branches interactively and confirm `harness.config.json` afterward (deferred — request from reviewer if needed before merge).

## Out of scope (per issue #49)

Wiring the actual pipeline runners to launch the chosen coding agent, auth handling for each agent, telemetry/log parsing for non-harnext agents — all explicit follow-ups.