### PR TITLE
chore(release): bump version to 1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6731,7 +6731,7 @@
     },
     "packages/cli": {
       "name": "harnext",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@mariozechner/pi-agent-core": "^0.67.68",
@@ -6744,7 +6744,7 @@
         "harnext": "dist/index.js"
       },
       "devDependencies": {
-        "@harnext/core": "^0.1.0"
+        "@harnext/core": "^1.0.0"
       },
       "engines": {
         "node": ">=20"
@@ -6764,7 +6764,7 @@
     },
     "packages/core": {
       "name": "@harnext/core",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@mariozechner/pi-agent-core": "^0.67.68",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harnext",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "AI coding agent with harness engineering — interactive REPL, MCP support, and a GitHub-issue-driven workflow runner.",
   "type": "module",
   "bin": {
@@ -26,7 +26,7 @@
     "yaml": "^2.5.0"
   },
   "devDependencies": {
-    "@harnext/core": "^0.1.0"
+    "@harnext/core": "^1.0.0"
   },
   "engines": {
     "node": ">=20"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harnext/core",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Core library for harnext AI coding agent (bundled into the harnext CLI; not published separately).",
   "private": true,
   "type": "module",


### PR DESCRIPTION
Bumps both workspaces to **1.0.0** ahead of the first npm publish under the new `harnext` name.

- `packages/cli/package.json` — version → 1.0.0; devDependency `@harnext/core` → ^1.0.0
- `packages/core/package.json` — version → 1.0.0 (still `private: true`, bundled into the CLI by tsup)
- `package-lock.json` — refreshed

Once merged, tag `v1.0.0` on `main` to trigger `.github/workflows/release.yml` and publish `harnext@1.0.0` to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)