### PR TITLE
feat(cli): add 'harnext upgrade' subcommand

### DIFF
--- a/packages/cli/src/cli/args.ts
+++ b/packages/cli/src/cli/args.ts
@@ -7,7 +7,8 @@ export type Mode =
   | 'github-poll'
   | 'mcp'
   | 'setup'
-  | 'status';
+  | 'status'
+  | 'upgrade';
 export type McpVerb = 'add' | 'remove' | 'list' | 'reconnect';
 export type McpScopeArg = 'user' | 'project';
 
@@ -33,6 +34,10 @@ export interface Args {
   mcpDirect?: boolean;
   /** Positional args after `--` for mcp add stdio: command + args. */
   mcpCommandArgs?: string[];
+  /** `harnext upgrade --check` — preview only, do not run npm install. */
+  upgradeCheck?: boolean;
+  /** `harnext upgrade --force` — reinstall even when already on latest. */
+  upgradeForce?: boolean;
 }
 
 export function parseArgs(argv: string[]): Args {
@@ -53,6 +58,10 @@ export function parseArgs(argv: string[]): Args {
 
   if (argv[0] === 'status') {
     return parseStatusArgs(argv.slice(1), args);
+  }
+
+  if (argv[0] === 'upgrade') {
+    return parseUpgradeArgs(argv.slice(1), args);
   }
 
   let i = 0;
@@ -140,6 +149,47 @@ Usage:
 Lists each registered worktree (per open issue/PR), the branch checked out,
 any coding-agent process currently running against it (with stage + elapsed
 time), and the uncommitted file changes present in the worktree.
+`);
+}
+
+function parseUpgradeArgs(rest: string[], args: Args): Args {
+  args.mode = 'upgrade';
+  let i = 0;
+  while (i < rest.length) {
+    const arg = rest[i];
+    switch (arg) {
+      case '--check':
+        args.upgradeCheck = true;
+        break;
+      case '--force':
+        args.upgradeForce = true;
+        break;
+      case '-h':
+      case '--help':
+        printUpgradeHelp();
+        process.exit(0);
+        break;
+      default:
+        break;
+    }
+    i++;
+  }
+  return args;
+}
+
+export function printUpgradeHelp(): void {
+  console.log(`
+harnext upgrade - Install the latest published harnext from npm
+
+Usage:
+  harnext upgrade [--check] [--force]
+
+Options:
+  --check                  Print the available version without installing
+  --force                  Reinstall even when already on the latest version
+
+Runs 'npm install -g harnext@<latest>' under the hood, so the user's existing
+global prefix, registry, and auth settings are respected.
 `);
 }
 
@@ -280,6 +330,7 @@ Options:
 Subcommands:
   setup                    Pick a coding agent and configure the project pipeline
   status                   Show active coding-agent runs (worktrees + processes)
+  upgrade                  Install the latest harnext from npm
   mcp                      Manage MCP servers (run \`harnext mcp --help\`)
 `);
 }

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -27,6 +27,7 @@ import {
   runMcpMode,
   runPrintMode,
   runStatusMode,
+  runUpgradeMode,
 } from './modes/index.js';
 
 const FALLBACK_PROVIDER = 'anthropic';
@@ -67,6 +68,14 @@ export async function main(argv: string[]): Promise<void> {
 
   if (args.mode === 'status') {
     const exitCode = await runStatusMode({ cwd: args.cwd });
+    process.exit(exitCode);
+  }
+
+  if (args.mode === 'upgrade') {
+    const exitCode = await runUpgradeMode({
+      check: args.upgradeCheck,
+      force: args.upgradeForce,
+    });
     process.exit(exitCode);
   }
 

--- a/packages/cli/src/modes/index.ts
+++ b/packages/cli/src/modes/index.ts
@@ -4,3 +4,4 @@ export { runHeartbeatMode, type HeartbeatModeOptions } from './heartbeat-mode.js
 export { runGithubPollMode, type GithubPollModeOptions } from './github-poll-mode.js';
 export { runMcpMode } from './mcp-mode.js';
 export { runStatusMode, type StatusModeOptions } from './status-mode.js';
+export { runUpgradeMode, type UpgradeModeOptions } from './upgrade-mode.js';

--- a/packages/cli/src/modes/upgrade-mode.ts
+++ b/packages/cli/src/modes/upgrade-mode.ts
@@ -1,0 +1,180 @@
+/**
+ * `harnext upgrade` — install the latest published `harnext` from npm.
+ *
+ * Reads the running CLI's version, queries the npm registry's `latest`
+ * dist-tag, and (when an upgrade is warranted) shells out to
+ * `npm install -g harnext@latest`. The actual install is delegated to npm
+ * so the user's existing global prefix, registry, and auth settings are
+ * respected without duplication.
+ */
+
+import { spawn } from 'node:child_process';
+
+import chalk from 'chalk';
+
+import { VERSION } from '@harnext/core';
+
+const REGISTRY_URL = 'https://registry.npmjs.org/harnext/latest';
+const PACKAGE_NAME = 'harnext';
+
+export interface UpgradeModeOptions {
+  /** Print the comparison only — do not actually run npm install. */
+  check?: boolean;
+  /** Reinstall even when the running version already matches the latest. */
+  force?: boolean;
+}
+
+/**
+ * Compare two semver-ish version strings. Returns 1 if `a > b`, -1 if
+ * `a < b`, 0 if equal. Pre-release suffixes (`-rc.1` etc.) are compared
+ * as ASCII strings, which is good enough for the upgrade-vs-no-upgrade
+ * decision; we don't need full semver precedence rules here.
+ */
+export function compareVersions(a: string, b: string): number {
+  const split = (v: string): { nums: number[]; pre: string } => {
+    const dash = v.indexOf('-');
+    const core = dash >= 0 ? v.slice(0, dash) : v;
+    const pre = dash >= 0 ? v.slice(dash + 1) : '';
+    const nums = core.split('.').map((p) => Number.parseInt(p, 10) || 0);
+    return { nums, pre };
+  };
+
+  const A = split(a);
+  const B = split(b);
+  const len = Math.max(A.nums.length, B.nums.length);
+  for (let i = 0; i < len; i++) {
+    const av = A.nums[i] ?? 0;
+    const bv = B.nums[i] ?? 0;
+    if (av !== bv) return av > bv ? 1 : -1;
+  }
+  // Equal cores: a release (no pre) outranks any pre-release of the same core.
+  if (A.pre === B.pre) return 0;
+  if (A.pre === '') return 1;
+  if (B.pre === '') return -1;
+  return A.pre > B.pre ? 1 : -1;
+}
+
+interface FetchOptions {
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * Resolve the current `latest` dist-tag of `harnext` on the npm registry.
+ * Throws on network or HTTP failures so the caller can surface the error.
+ */
+export async function fetchLatestVersion(opts: FetchOptions = {}): Promise<string> {
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const res = await fetchImpl(REGISTRY_URL, {
+    headers: { accept: 'application/json' },
+  });
+  if (!res.ok) {
+    throw new Error(`registry returned HTTP ${res.status} ${res.statusText}`);
+  }
+  const data = (await res.json()) as { version?: unknown };
+  if (typeof data.version !== 'string' || data.version.length === 0) {
+    throw new Error('registry response is missing a version field');
+  }
+  return data.version;
+}
+
+interface NpmRunner {
+  /** Resolve to the npm exit code. */
+  run(target: string): Promise<number>;
+}
+
+const defaultNpmRunner: NpmRunner = {
+  run(target) {
+    return new Promise((resolve, reject) => {
+      const child = spawn('npm', ['install', '-g', target], {
+        stdio: 'inherit',
+        env: process.env,
+      });
+      child.once('error', reject);
+      child.once('close', (code) => resolve(code ?? 1));
+    });
+  },
+};
+
+export interface UpgradeModeDeps {
+  fetchLatest?: () => Promise<string>;
+  npm?: NpmRunner;
+  /** Output sink (defaults to console). Tests inject a buffer. */
+  log?: (line: string) => void;
+  errLog?: (line: string) => void;
+  /** Override of the running version (defaults to the bundled VERSION). */
+  currentVersion?: string;
+}
+
+export async function runUpgradeMode(
+  options: UpgradeModeOptions = {},
+  deps: UpgradeModeDeps = {},
+): Promise<number> {
+  const log = deps.log ?? ((s: string) => console.log(s));
+  const errLog = deps.errLog ?? ((s: string) => console.error(s));
+  const fetchLatest = deps.fetchLatest ?? fetchLatestVersion;
+  const npm = deps.npm ?? defaultNpmRunner;
+  const current = deps.currentVersion ?? VERSION;
+
+  log(`Current version: ${chalk.cyan(current)}`);
+
+  let latest: string;
+  try {
+    latest = await fetchLatest();
+  } catch (err) {
+    errLog(
+      chalk.red(
+        `Could not check the npm registry: ${err instanceof Error ? err.message : String(err)}`,
+      ),
+    );
+    return 1;
+  }
+
+  log(`Latest on npm:   ${chalk.cyan(latest)}`);
+
+  const cmp = compareVersions(latest, current);
+
+  if (cmp === 0 && !options.force) {
+    log(chalk.green(`✓ Already on the latest version.`));
+    return 0;
+  }
+
+  if (cmp < 0 && !options.force) {
+    log(
+      chalk.yellow(
+        `Your version (${current}) is ahead of npm latest (${latest}) — likely installed from source.`,
+      ),
+    );
+    log(chalk.dim(`Re-run with --force to downgrade to the published version.`));
+    return 0;
+  }
+
+  if (options.check) {
+    log(
+      cmp > 0
+        ? chalk.yellow(`An upgrade is available: ${current} → ${latest}`)
+        : chalk.dim('No upgrade needed.'),
+    );
+    return 0;
+  }
+
+  const target = `${PACKAGE_NAME}@${latest}`;
+  log(
+    cmp > 0
+      ? `Upgrading ${chalk.cyan(current)} → ${chalk.cyan(latest)}…`
+      : `Reinstalling ${chalk.cyan(target)}…`,
+  );
+
+  const exit = await npm.run(target);
+  if (exit !== 0) {
+    errLog(
+      chalk.red(
+        `npm install exited with code ${exit}. If this is a permissions error, ` +
+          `check 'npm config get prefix' and ensure its bin directory is writable.`,
+      ),
+    );
+    return exit;
+  }
+
+  log(chalk.green(`✓ Installed ${target}.`));
+  return 0;
+}

--- a/packages/cli/tests/upgrade-mode.test.ts
+++ b/packages/cli/tests/upgrade-mode.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  compareVersions,
+  runUpgradeMode,
+  type UpgradeModeDeps,
+} from '../src/modes/upgrade-mode.js';
+
+describe('compareVersions', () => {
+  it.each([
+    ['1.0.0', '1.0.0', 0],
+    ['1.0.1', '1.0.0', 1],
+    ['1.0.0', '1.0.1', -1],
+    ['1.2.0', '1.10.0', -1],
+    ['2.0.0', '1.99.99', 1],
+    ['1.0.0', '1.0.0-rc.1', 1],
+    ['1.0.0-rc.1', '1.0.0', -1],
+    ['1.0.0-rc.2', '1.0.0-rc.1', 1],
+  ])('compareVersions(%s, %s) → %d', (a, b, expected) => {
+    expect(compareVersions(a, b)).toBe(expected);
+  });
+});
+
+function makeDeps(overrides: Partial<UpgradeModeDeps> = {}): {
+  deps: UpgradeModeDeps;
+  out: string[];
+  err: string[];
+  npmCalls: string[];
+} {
+  const out: string[] = [];
+  const err: string[] = [];
+  const npmCalls: string[] = [];
+  const deps: UpgradeModeDeps = {
+    log: (line) => out.push(line),
+    errLog: (line) => err.push(line),
+    fetchLatest: async () => '1.0.0',
+    npm: {
+      run: async (target) => {
+        npmCalls.push(target);
+        return 0;
+      },
+    },
+    currentVersion: '1.0.0',
+    ...overrides,
+  };
+  return { deps, out, err, npmCalls };
+}
+
+describe('runUpgradeMode', () => {
+  it('reports already-on-latest and skips npm install', async () => {
+    const { deps, out, npmCalls } = makeDeps();
+    const exit = await runUpgradeMode({}, deps);
+    expect(exit).toBe(0);
+    expect(npmCalls).toEqual([]);
+    expect(out.join('\n')).toMatch(/Already on the latest/);
+  });
+
+  it('runs npm install when an upgrade is available', async () => {
+    const { deps, out, npmCalls } = makeDeps({
+      currentVersion: '1.0.0',
+      fetchLatest: async () => '1.2.3',
+    });
+    const exit = await runUpgradeMode({}, deps);
+    expect(exit).toBe(0);
+    expect(npmCalls).toEqual(['harnext@1.2.3']);
+    expect(out.join('\n')).toMatch(/Upgrading.*1\.0\.0.*1\.2\.3/);
+    expect(out.join('\n')).toMatch(/Installed harnext@1\.2\.3/);
+  });
+
+  it('does not downgrade when local is ahead of npm latest', async () => {
+    const { deps, out, npmCalls } = makeDeps({
+      currentVersion: '2.0.0-dev',
+      fetchLatest: async () => '1.0.0',
+    });
+    const exit = await runUpgradeMode({}, deps);
+    expect(exit).toBe(0);
+    expect(npmCalls).toEqual([]);
+    expect(out.join('\n')).toMatch(/ahead of npm latest/);
+    expect(out.join('\n')).toMatch(/--force/);
+  });
+
+  it('--force reinstalls even when already on latest', async () => {
+    const { deps, npmCalls } = makeDeps();
+    const exit = await runUpgradeMode({ force: true }, deps);
+    expect(exit).toBe(0);
+    expect(npmCalls).toEqual(['harnext@1.0.0']);
+  });
+
+  it('--check prints the available upgrade without installing', async () => {
+    const { deps, out, npmCalls } = makeDeps({
+      currentVersion: '1.0.0',
+      fetchLatest: async () => '1.1.0',
+    });
+    const exit = await runUpgradeMode({ check: true }, deps);
+    expect(exit).toBe(0);
+    expect(npmCalls).toEqual([]);
+    expect(out.join('\n')).toMatch(/upgrade is available: 1\.0\.0 → 1\.1\.0/);
+  });
+
+  it('returns 1 and logs to stderr when the registry fetch fails', async () => {
+    const { deps, err, npmCalls } = makeDeps({
+      fetchLatest: async () => {
+        throw new Error('ENETUNREACH');
+      },
+    });
+    const exit = await runUpgradeMode({}, deps);
+    expect(exit).toBe(1);
+    expect(npmCalls).toEqual([]);
+    expect(err.join('\n')).toMatch(/Could not check the npm registry: ENETUNREACH/);
+  });
+
+  it('returns the npm exit code when npm install fails', async () => {
+    const { deps, err } = makeDeps({
+      fetchLatest: async () => '1.1.0',
+      npm: {
+        run: vi.fn(async () => 13),
+      },
+    });
+    const exit = await runUpgradeMode({}, deps);
+    expect(exit).toBe(13);
+    expect(err.join('\n')).toMatch(/npm install exited with code 13/);
+  });
+});


### PR DESCRIPTION
## Summary

- New `harnext upgrade` subcommand that installs the latest published `harnext` from npm in one shot — no need to remember `npm install -g harnext@latest`.
- Reads the running CLI's bundled `VERSION`, fetches the npm registry's `latest` dist-tag, and (when an upgrade is warranted) shells out to `npm install -g harnext@<latest>`. The install itself is delegated to npm so the user's existing global prefix, registry, and auth settings are respected.
- Refuses to silently downgrade: if the running version is ahead of npm latest (e.g., a local dev build), the command tells the user to pass `--force`.

## Flags

- `--check` — print the comparison only; do not install.
- `--force` — reinstall even when already on latest, and override the ahead-of-latest guard.

## Test plan

- [x] `npm test` — 219/219 pass (15 new tests in `packages/cli/tests/upgrade-mode.test.ts`)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run build` — bundles cleanly
- [ ] Manual: `node packages/cli/dist/index.js upgrade --check`
- [ ] Manual: `node packages/cli/dist/index.js upgrade --help`

## Notes

- `runUpgradeMode` takes an `UpgradeModeDeps` for the registry fetch and npm spawn, so the flows are unit-tested without touching the network or shelling out.
- `compareVersions` is a small in-house semver-ish comparator (no new dependency); pre-release suffixes are compared as strings — good enough for upgrade-vs-no-upgrade decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)