### PR TITLE
chore(release): bump version to 1.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6731,7 +6731,7 @@
     },
     "packages/cli": {
       "name": "harnext",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@mariozechner/pi-agent-core": "^0.67.68",
@@ -6744,7 +6744,7 @@
         "harnext": "dist/index.js"
       },
       "devDependencies": {
-        "@harnext/core": "^1.0.0"
+        "@harnext/core": "^1.0.1"
       },
       "engines": {
         "node": ">=20"
@@ -6764,7 +6764,7 @@
     },
     "packages/core": {
       "name": "@harnext/core",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@mariozechner/pi-agent-core": "^0.67.68",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harnext",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "AI coding agent with harness engineering — interactive REPL, MCP support, and a GitHub-issue-driven workflow runner.",
   "type": "module",
   "bin": {
@@ -26,7 +26,7 @@
     "yaml": "^2.5.0"
   },
   "devDependencies": {
-    "@harnext/core": "^1.0.0"
+    "@harnext/core": "^1.0.1"
   },
   "engines": {
     "node": ">=20"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harnext/core",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Core library for harnext AI coding agent (bundled into the harnext CLI; not published separately).",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## Summary

Patch release covering #68 — adds the `skill` tool so models stop hallucinating skill names as tool calls.

- `packages/cli/package.json`: 1.0.0 → 1.0.1, `@harnext/core` devDep `^1.0.0` → `^1.0.1`
- `packages/core/package.json`: 1.0.0 → 1.0.1
- `package-lock.json`: regenerated

Once merged, tag `v1.0.1` from `main` and push the tag — `.github/workflows/release.yml` will publish to npm.

## Test plan

- [x] `npm install` clean
- [x] `npm run build`
- [x] `npm test` (338/338)

🤖 Generated with [Claude Code](https://claude.com/claude-code)