### PR TITLE
fix(core): derive VERSION from package.json (1.0.2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6731,7 +6731,7 @@
     },
     "packages/cli": {
       "name": "harnext",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "@mariozechner/pi-agent-core": "^0.67.68",
@@ -6744,7 +6744,7 @@
         "harnext": "dist/index.js"
       },
       "devDependencies": {
-        "@harnext/core": "^1.0.1"
+        "@harnext/core": "^1.0.2"
       },
       "engines": {
         "node": ">=20"
@@ -6764,7 +6764,7 @@
     },
     "packages/core": {
       "name": "@harnext/core",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "@mariozechner/pi-agent-core": "^0.67.68",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harnext",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "AI coding agent with harness engineering — interactive REPL, MCP support, and a GitHub-issue-driven workflow runner.",
   "type": "module",
   "bin": {
@@ -26,7 +26,7 @@
     "yaml": "^2.5.0"
   },
   "devDependencies": {
-    "@harnext/core": "^1.0.1"
+    "@harnext/core": "^1.0.2"
   },
   "engines": {
     "node": ">=20"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harnext/core",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Core library for harnext AI coding agent (bundled into the harnext CLI; not published separately).",
   "private": true,
   "type": "module",

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1,9 +1,51 @@
 import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 export const APP_NAME = 'harnext';
-export const VERSION = '0.1.0';
+
+/**
+ * Resolve the running package's version from its package.json. Walking up from
+ * `import.meta.url` covers both layouts the constant is read in:
+ *
+ *   - npm-published CLI: `<install>/dist/index.js` → `<install>/package.json`
+ *     (the bundled CLI's package.json — `harnext`).
+ *   - core run from source (tests, vitest): `<core>/src/config.ts` →
+ *     `<core>/package.json` (`@harnext/core`).
+ *
+ * The previous implementation hardcoded "0.1.0" and silently drifted from the
+ * package version every release. Reading at runtime keeps a single source of
+ * truth.
+ */
+function resolveVersion(): string {
+  try {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const candidates = [
+      join(here, '..', 'package.json'),
+      join(here, '..', '..', 'package.json'),
+    ];
+    for (const path of candidates) {
+      try {
+        const pkg = JSON.parse(readFileSync(path, 'utf-8')) as {
+          name?: string;
+          version?: string;
+        };
+        if ((pkg.name === 'harnext' || pkg.name === '@harnext/core') && pkg.version) {
+          return pkg.version;
+        }
+      } catch {
+        // Try the next candidate.
+      }
+    }
+  } catch {
+    // Fall through to the placeholder.
+  }
+  return '0.0.0';
+}
+
+export const VERSION = resolveVersion();
 export const CONFIG_DIR_NAME = '.harnext';
 
 /** Project-hash length used for deriving per-project state dirs. */

--- a/packages/core/tests/config.test.ts
+++ b/packages/core/tests/config.test.ts
@@ -1,9 +1,10 @@
+import { readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { getUserSkillsDir } from '../src/config.js';
+import { getUserSkillsDir, VERSION } from '../src/config.js';
 
 describe('getUserSkillsDir', () => {
   const originalEnv = process.env.HARNEXT_USER_SKILLS_DIR;
@@ -24,5 +25,18 @@ describe('getUserSkillsDir', () => {
   it('respects HARNEXT_USER_SKILLS_DIR override', () => {
     process.env.HARNEXT_USER_SKILLS_DIR = '/tmp/custom-skills';
     expect(getUserSkillsDir()).toBe('/tmp/custom-skills');
+  });
+});
+
+describe('VERSION', () => {
+  it('matches the version in @harnext/core package.json', () => {
+    // Regression: prior to 1.0.2, VERSION was a hardcoded string ('0.1.0')
+    // that drifted from package.json on every release. The runtime resolver
+    // must keep them in sync so `harnext --version` reports the actual
+    // installed version.
+    const pkg = JSON.parse(
+      readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'),
+    ) as { version: string };
+    expect(VERSION).toBe(pkg.version);
   });
 });


### PR DESCRIPTION
## Summary

`packages/core/src/config.ts` exported a hardcoded `VERSION = '0.1.0'` that nobody bumped. Every release — including the freshly-published 1.0.1 — shipped with the CLI reporting itself as `0.1.0` via:

- `harnext --version` (`packages/cli/src/cli/args.ts:105`)
- The interactive REPL header (`packages/cli/src/modes/interactive/render.ts:203`)
- The `harnext upgrade` current-vs-latest comparison (`packages/cli/src/modes/upgrade-mode.ts:146`) — would always claim an upgrade was available

This PR replaces the constant with a runtime resolver that reads the package's own `package.json` by walking up from `import.meta.url`. Two layouts work:

- npm-published CLI: `dist/index.js` → `../package.json` (`harnext`)
- core run from source (vitest): `src/config.ts` → `../package.json` (`@harnext/core`)

Adds a regression test pinning `VERSION` to the value in `package.json` so the drift can't recur.

Bumps cli + core to `1.0.2` so the fix actually ships — the existing 1.0.1 tarball also has `VERSION = "0.1.0"` baked in, so a release is required to see the right number anywhere.

## Test plan

- [x] `npm run typecheck`, `npm run lint`, `npm run build`
- [x] `npm test` — 339/339 (1 new regression test in `packages/core/tests/config.test.ts`)
- [x] End-to-end: `npm install <built-cli> && ./node_modules/.bin/harnext --version` → `1.0.2`
- [x] `node packages/cli/dist/index.js --version` → `1.0.2`

## Release follow-up

Once merged: tag `v1.0.2` and push the tag — `.github/workflows/release.yml` will publish to npm. After that, `harnext upgrade` (or `npm i -g harnext@latest`) will both install the right version and report it correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)