### PR TITLE
chore(release): bump version to 1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6731,7 +6731,7 @@
     },
     "packages/cli": {
       "name": "harnext",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@mariozechner/pi-agent-core": "^0.67.68",
@@ -6744,7 +6744,7 @@
         "harnext": "dist/index.js"
       },
       "devDependencies": {
-        "@harnext/core": "^1.0.2"
+        "@harnext/core": "^1.1.0"
       },
       "engines": {
         "node": ">=20"
@@ -6764,7 +6764,7 @@
     },
     "packages/core": {
       "name": "@harnext/core",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@mariozechner/pi-agent-core": "^0.67.68",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harnext",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "AI coding agent with harness engineering — interactive REPL, MCP support, and a GitHub-issue-driven workflow runner.",
   "type": "module",
   "bin": {
@@ -26,7 +26,7 @@
     "yaml": "^2.5.0"
   },
   "devDependencies": {
-    "@harnext/core": "^1.0.2"
+    "@harnext/core": "^1.1.0"
   },
   "engines": {
     "node": ">=20"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harnext/core",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Core library for harnext AI coding agent (bundled into the harnext CLI; not published separately).",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## Summary

Minor release covering #71. Both workspaces moved to `1.1.0` and the cli's devDependency on `@harnext/core` is bumped to match.

## Highlights since 1.0.2

- **Self-hosted runner replaces cron poller.** Every harnext stage runs as a GitHub Actions workflow now; `runs-on: self-hosted` (with a project-scoped label) is the new way to "run on this PC." ~1300 lines of poller machinery (lockfile, `lastSeenUpdatedAt` pointer, `--github-poll` flag, etc.) are gone.
- **Review-loop split into two coupled workflows** (review entry + fix companion). Deterministic decision tree gates fix dispatches on `verdict == changes_requested` AND `iter < maxIterations` — no more relying on the agent's prompt discipline for loop termination.
- **New post-merge `doc-gardening` stage** (terminal, `trigger: 'pr-merged'`). Keeps `/docs/` aligned with the codebase; opens a fresh `docs: update for #<pr>` PR when the merged change is significant, skips for trivial changes.
- **NVIDIA NIM provider** (build.nvidia.com). OpenAI-compatible, default model `deepseek-ai/deepseek-v4-pro`, live model discovery via `/v1/models`. Mirrors the ollama integration.
- **Planner + implementer prompts now consult `/docs/`** first for project conventions and subsystem docs.

## Breaking changes (kept the bump minor — public CLI surface migrates legacy configs in place; only SDK-internal types removed)

- Removed `--github-poll` CLI flag and its mode entry point.
- Removed `LocalRunner` / `GithubActionsRunner` / `StageRunnerKind` types from `@harnext/core` exports; `StageRunner` collapsed to `{ workflowPath; origin; runsOn }`. Legacy configs (`{ kind: 'local' }` / `{ kind: 'github-actions' }`) are migrated at load time.
- `IntakeStage` collapsed from `{ runner: StageRunner }` to `{ enabled: boolean }`. Legacy shape migrated at load time.

## Test plan

- [x] `npm test` — 312/312 pass
- [x] `npm run typecheck` — clean across both workspaces
- [x] `npm run lint` — clean
- [x] `npm run build` — both packages build to dist
- [ ] Manual e2e: `harnext --version` reports `1.1.0` after `npm install -g harnext@1.1.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)