### PR TITLE
feat(cli): branch safety + friendly completion message in setup wizard

### DIFF
--- a/packages/cli/src/cli/github-prompt.ts
+++ b/packages/cli/src/cli/github-prompt.ts
@@ -10,6 +10,7 @@ import {
   NEEDS_JUDGMENT_LABEL,
   buildHarnextLabelSpecs,
   checkPublicRepoApprovalGate,
+  createAndSwitchBranch,
   defaultStageWorkflowPath,
   deleteGithubConnection,
   deregisterRunner,
@@ -17,6 +18,7 @@ import {
   ensureRepoLabels,
   generateStageWorkflow,
   getCodingAgentSpec,
+  getCurrentGitBranch,
   getGithubConfigPath,
   getRepoFromCwd,
   getStageRunner,
@@ -1614,6 +1616,104 @@ async function runAnalysisStep(
   return applyDefaultRunners(result.stages, result.techStack);
 }
 
+const SETUP_BRANCH_NAME = 'feat/setup-harnext';
+
+/**
+ * Warn the user when the setup wizard (`harnext setup` or `/connect-github`)
+ * is invoked on the default branch (main/master) and offer to switch to a
+ * fresh feature branch. Returns `false` if the user explicitly aborts so
+ * the caller can stop the wizard. Skipped silently outside of git repos
+ * and on any non-default branch.
+ */
+async function runBranchSafetyStep(cwd: string): Promise<boolean> {
+  const branch = getCurrentGitBranch(cwd);
+  if (branch !== 'main' && branch !== 'master') return true;
+
+  console.log(chalk.bold('  Step: working branch'));
+  console.log(
+    chalk.yellow(`  You are on the default branch (${branch}).`),
+  );
+  console.log(
+    chalk.dim(
+      '    Setup writes workflow files and configuration to this repo. We',
+    ),
+  );
+  console.log(
+    chalk.dim(
+      '    recommend doing it on a feature branch so the changes can land via PR.',
+    ),
+  );
+  console.log();
+
+  const accept = await confirm(
+    `Create branch "${SETUP_BRANCH_NAME}" and continue?`,
+    true,
+  );
+  if (!accept) {
+    console.log(
+      chalk.dim('  Continuing on ') + chalk.cyan(branch) + chalk.dim('.'),
+    );
+    console.log();
+    return true;
+  }
+
+  const result = createAndSwitchBranch(cwd, SETUP_BRANCH_NAME);
+  if (!result.ok) {
+    console.log(chalk.red(`  Could not create branch: ${result.message}`));
+    const cont = await confirm(`Continue on ${branch} anyway?`, false);
+    if (!cont) {
+      console.log(chalk.dim('  Cancelled.'));
+      console.log();
+      return false;
+    }
+    console.log();
+    return true;
+  }
+
+  console.log(
+    chalk.green('  Switched to new branch ') + chalk.cyan(SETUP_BRANCH_NAME),
+  );
+  console.log();
+  return true;
+}
+
+/**
+ * Friendly closing message after a successful save. Tailors the suggested
+ * next step to whether the user is on a feature branch (open a PR) or the
+ * default branch (commit + push directly).
+ */
+function printSetupComplete(cwd: string, cfg: GithubConnectionConfig): void {
+  const branch = getCurrentGitBranch(cwd);
+  const onDefaultBranch = branch === 'main' || branch === 'master';
+
+  console.log(chalk.green.bold('  Your harness is ready!'));
+  console.log();
+  console.log(chalk.bold('  Next steps:'));
+  console.log(
+    chalk.dim('    1. Review the generated files under ') +
+      chalk.cyan('.github/workflows/'),
+  );
+  if (onDefaultBranch || !branch) {
+    console.log(
+      chalk.dim('    2. Commit and push them to ') + chalk.cyan(cfg.repo),
+    );
+  } else {
+    console.log(
+      chalk.dim('    2. Commit them on ') +
+        chalk.cyan(branch) +
+        chalk.dim(' and open a PR to merge into main'),
+    );
+  }
+  console.log(
+    chalk.dim('    3. Label an issue with ') +
+      chalk.cyan(cfg.stages[0]?.label ?? 'the first stage label') +
+      chalk.dim(' and watch the harness run.'),
+  );
+  console.log();
+  console.log(chalk.green('  Happy harnessing!'));
+  console.log();
+}
+
 /**
  * Create (or edit) flow. When `current` is passed, its values are used as
  * defaults so the user can keep fields unchanged by accepting the default.
@@ -1629,6 +1729,10 @@ async function createFlow(
   // harnext — this is the implicit agent context of `/connect-github`, so
   // we never ask. In full mode we always ask, because `harnext setup` is
   // the place where the user chooses how the pipeline runs.
+  if (!(await runBranchSafetyStep(opts.cwd))) {
+    return;
+  }
+
   let codingAgent: CodingAgentId = current?.codingAgent ?? 'harnext';
   let codingAgentModel: string | undefined = current?.codingAgentModel;
 
@@ -1996,6 +2100,8 @@ async function createFlow(
     console.log(chalk.green(savedMsg));
     console.log(chalk.dim(`    config: ${getGithubConfigPath(opts.cwd)}`));
     console.log();
+
+    printSetupComplete(opts.cwd, cfg);
   } catch (err) {
     console.log(
       chalk.red('  Failed to save config: ') +

--- a/packages/core/src/git-branch.ts
+++ b/packages/core/src/git-branch.ts
@@ -1,0 +1,53 @@
+import { execFileSync } from 'node:child_process';
+
+export interface GitBranchOk {
+  ok: true;
+  branch: string;
+}
+
+export interface GitBranchError {
+  ok: false;
+  message: string;
+}
+
+export type GitBranchResult = GitBranchOk | GitBranchError;
+
+/**
+ * Read the current branch name via `git rev-parse --abbrev-ref HEAD`.
+ * Returns `null` when the directory is not a git repo, git isn't installed,
+ * or HEAD is detached (`HEAD` is filtered out).
+ */
+export function getCurrentGitBranch(cwd: string): string | null {
+  try {
+    const stdout = execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
+      cwd,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    const branch = stdout.trim();
+    if (!branch || branch === 'HEAD') return null;
+    return branch;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Create and switch to a new branch from the current HEAD.
+ * Fails if the branch already exists — caller decides how to react.
+ */
+export function createAndSwitchBranch(cwd: string, name: string): GitBranchResult {
+  try {
+    execFileSync('git', ['checkout', '-b', name], {
+      cwd,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return { ok: true, branch: name };
+  } catch (err: unknown) {
+    const e = err as { stderr?: Buffer | string; message?: string };
+    const stderr = typeof e.stderr === 'string' ? e.stderr : e.stderr?.toString('utf-8') ?? '';
+    const message = stderr.trim() || e.message || 'git checkout failed';
+    return { ok: false, message };
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -195,6 +195,12 @@ export {
 } from './github-connection.js';
 
 export {
+  createAndSwitchBranch,
+  getCurrentGitBranch,
+  type GitBranchResult,
+} from './git-branch.js';
+
+export {
   PINNED_RUNNER_VERSION,
   buildArchiveName,
   buildTarballUrl,

--- a/packages/core/tests/git-branch.test.ts
+++ b/packages/core/tests/git-branch.test.ts
@@ -1,0 +1,67 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createAndSwitchBranch, getCurrentGitBranch } from '../src/git-branch.js';
+
+function git(cwd: string, args: string[]): void {
+  execFileSync('git', args, {
+    cwd,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: 'test',
+      GIT_AUTHOR_EMAIL: 'test@example.com',
+      GIT_COMMITTER_NAME: 'test',
+      GIT_COMMITTER_EMAIL: 'test@example.com',
+    },
+  });
+}
+
+describe('git-branch helpers', () => {
+  let cwd: string;
+
+  beforeEach(() => {
+    cwd = mkdtempSync(join(tmpdir(), 'harnext-git-branch-'));
+    git(cwd, ['init', '-q', '-b', 'main']);
+    git(cwd, ['commit', '-q', '--allow-empty', '-m', 'init']);
+  });
+
+  afterEach(() => {
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it('returns the current branch name', () => {
+    expect(getCurrentGitBranch(cwd)).toBe('main');
+  });
+
+  it('returns null outside of a git repo', () => {
+    const notRepo = mkdtempSync(join(tmpdir(), 'harnext-not-repo-'));
+    try {
+      expect(getCurrentGitBranch(notRepo)).toBeNull();
+    } finally {
+      rmSync(notRepo, { recursive: true, force: true });
+    }
+  });
+
+  it('creates and switches to a new branch', () => {
+    const result = createAndSwitchBranch(cwd, 'feat/setup-harnext');
+    expect(result.ok).toBe(true);
+    expect(getCurrentGitBranch(cwd)).toBe('feat/setup-harnext');
+  });
+
+  it('fails when the branch already exists', () => {
+    expect(createAndSwitchBranch(cwd, 'feat/setup-harnext').ok).toBe(true);
+    git(cwd, ['checkout', '-q', 'main']);
+
+    const result = createAndSwitchBranch(cwd, 'feat/setup-harnext');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toMatch(/already exists/i);
+    }
+    expect(getCurrentGitBranch(cwd)).toBe('main');
+  });
+});


### PR DESCRIPTION
## Summary
- `harnext setup` and `/connect-github` now warn when invoked on `main`/`master` and offer to create `feat/setup-harnext` before writing any workflow files. Skipped silently outside git repos and on any non-default branch.
- Wizard ends with a branch-aware "Your harness is ready!" message — recommends opening a PR when on a feature branch, or commit + push when the user stayed on the default branch. Always points at the first stage label so they know how to kick off the pipeline.
- New `getCurrentGitBranch` / `createAndSwitchBranch` helpers in `@harnext/core`, plus a unit test against a real temp git repo.

## Test plan
- [ ] `npm run typecheck`, `npm run lint`, `npm test` (316 passing locally, +4 new)
- [ ] On `main`: run `harnext setup`, accept branch prompt → ends up on `feat/setup-harnext`
- [ ] On `main`: run `harnext setup`, decline branch prompt → continues on `main`, completion message says "Commit and push them to <repo>"
- [ ] On any other branch: setup runs as before with no branch step, completion message says "Commit them on <branch> and open a PR"
- [ ] `feat/setup-harnext` already exists → wizard reports the failure and asks whether to continue on the default branch
- [ ] Same flow via `/connect-github` slash command

🤖 Generated with [Claude Code](https://claude.com/claude-code)